### PR TITLE
Move deployment from GitHub pages to Vercel

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -4,68 +4,21 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
   pull_request:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-
-      - run: npm ci
-
-      - run: npm run lint
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - lint
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-
-      - run: npm ci
-
-      - name: Build site
-        run: npm run build
-        env:
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "./out"
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  ci-cd:
+    name: CI/CD
+    permissions:
+      contents: read
+      packages: read
+      deployments: write
+    uses: significa/actions/.github/workflows/vercel-app.yaml@main
+    with:
+      production_branch: main
+      # production_domain: ${{ vars.PRODUCTION_DOMAIN }}
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: read
       deployments: write
-    uses: significa/actions/.github/workflows/vercel-app.yaml@main
+    uses: significa/actions/.github/workflows/vercel-app.yaml@vercel-app-simple-strategy
     with:
       production_branch: main
       # production_domain: ${{ vars.PRODUCTION_DOMAIN }}

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -16,6 +16,10 @@ jobs:
       deployments: write
     uses: significa/actions/.github/workflows/vercel-app.yaml@vercel-app-simple-strategy
     with:
+      lint_command: npm run lint
+      test_command: null
+      staging_branch: null
+      staging_domain: null
       production_branch: main
       # production_domain: ${{ vars.PRODUCTION_DOMAIN }}
     secrets:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -21,7 +21,7 @@ jobs:
       staging_branch: null
       staging_domain: null
       production_branch: main
-      # production_domain: ${{ vars.PRODUCTION_DOMAIN }}
+      production_domain: ${{ vars.PRODUCTION_DOMAIN }}
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+    "outputDirectory": "out"
+}


### PR DESCRIPTION
We still keep the site static, but this way it is easier to have deployment previews (and the complications we also sometimes like)