### PR TITLE
fix: add explicit button type to calendar buttons

### DIFF
--- a/src/foundations/ui/calendar/calendar.tsx
+++ b/src/foundations/ui/calendar/calendar.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { add, format, isSameDay, isSameMonth } from "date-fns";
 import { CaretLeft, CaretRight } from "@phosphor-icons/react";
+import { add, format, isSameDay, isSameMonth } from "date-fns";
+import { useMemo, useState } from "react";
 
-import { cn } from "@/lib/utils";
 import { Button } from "@/foundations/ui/button/button";
+import { cn } from "@/lib/utils";
 
 /**
  * Generate a matrix of dates for a given month
@@ -282,6 +282,7 @@ const Calendar = ({
 
               return (
                 <button
+                  type="button"
                   key={ii}
                   aria-label={format(day, "yyyy-MM-dd")}
                   data-other-month={!isSameMonth(day, viewDate) || undefined}
@@ -376,6 +377,7 @@ const HeaderTextButton = ({
 }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
     <button
+      type="button"
       className={cn(
         "ring-ring text-foreground/80 hover:text-foreground focus-visible:text-foreground cursor-pointer rounded-sm font-medium transition outline-none focus-visible:ring-4",
         className
@@ -394,6 +396,7 @@ const YearMonthButton = ({
 }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
     <button
+      type="button"
       className={cn(
         "ring-ring text-foreground/80 hover:bg-background-secondary hover:text-foreground focus-visible:text-foreground h-8 w-full cursor-pointer rounded-lg text-sm font-medium transition outline-none focus-visible:ring-4",
         className


### PR DESCRIPTION
Since the default type for a button is submit, using this calendar in the datepicker and clicking on a button to change the date would automatically submit the form the datepicker would be on.

Fixes #83 