### PR TITLE
Font customisation and pairings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,6 @@ Some items will be impossible to do until there is decent baseline support for t
 - [ ] Select VS Listbox. If styling selects is baseline we should try to see if Listbox can be replaced by more customisation in the native Select component.
 - [ ] Drag to dismiss drawer (at least on mobile).
 - [ ] EPIC: React Native (completely different route, but same codebase?). We have a lot of projects in React Native with seriously good design systems (reanimated instead of motion). Check our codebases and plan this.
-- [ ] EPIC: Semantic typography tokens. Today we expose `--font-sans` and `--font-mono`, and most components inherit `font-family` from `body`. That's enough for a single brand sans, but real-world DS typography is _paired_ — a sophisticated serif like Playfair Display (made for big sizes — see "Display" in the name) should not be applied blindly to Badge, IconButton, or anything that uppercases or scales small. The path forward is explicit semantic tokens (`--font-heading`, `--font-body`, `--font-mono`, possibly `--font-display`) with components opting in: Badge, uppercase labels, and other UI chrome hardcode `var(--font-body)` (or a dedicated `--font-ui` token) so they never inherit a display font. Once that's in place, the DS panel typography chooser splits into 2–3 selectors. Surfaced while building the chooser — auditioning Playfair revealed exactly this problem. Typography is one of the things we care most about at Significa, and the DS primitives need to treat it with respect.
 
 ## Missing components
 

--- a/src/components/ds-config/ds-config.tsx
+++ b/src/components/ds-config/ds-config.tsx
@@ -9,6 +9,12 @@ import { CopyButton } from '@/components/copy-button';
 import { IconButton } from '@/foundations/ui/button/button';
 import { Popover } from '@/foundations/ui/popover/popover';
 import { Slider } from '@/foundations/ui/slider/slider';
+import {
+  DEFAULT_PAIRING,
+  findPairing,
+  PAIRINGS,
+  type Pairing,
+} from './pairings';
 import { SchemeEditor } from './scheme-editor';
 import {
   COLOR_TOKENS,
@@ -20,19 +26,24 @@ import {
   type TokenValues,
 } from './schemes';
 import {
+  EMPTY_FONTS,
+  type FontSlot,
   RADIUS_DEFAULT,
   RING_DEFAULT,
   readStored,
   type StoredFont,
+  type StoredFonts,
   writeStored,
 } from './storage';
-import { TypographyPicker } from './typography-picker';
+import { TypographyEditor } from './typography-editor';
 import { fallbackFor, loadGoogleFont } from './use-fonts-catalog';
 
 const RADIUS_STEP_REM = 0.0625;
 const RADIUS_MAX = 4;
 const RING_MIN = 2;
 const RING_MAX = 6;
+
+type View = 'presets' | 'edit-colors' | 'edit-fonts';
 
 const setRoot = (prop: string, value: string) =>
   document.documentElement.style.setProperty(prop, value);
@@ -54,6 +65,16 @@ const resolveToken = (
   token: ColorToken
 ): TokenValues => overrides[token] ?? scheme.colors[token];
 
+const fontFamilyValue = (font: StoredFont) =>
+  `'${font.family}', ${fallbackFor(font.category)}`;
+
+const FONT_SLOTS: FontSlot[] = ['heading', 'body', 'mono'];
+const FONT_VAR: Record<FontSlot, string> = {
+  heading: '--font-heading',
+  body: '--font-body',
+  mono: '--font-mono',
+};
+
 const DSConfig = () => {
   const stored = readStored();
   const initialScheme =
@@ -65,13 +86,15 @@ const DSConfig = () => {
   >(stored.overrides);
   const [radiusStep, setRadiusStep] = useState(stored.radiusStep);
   const [ringWidth, setRingWidth] = useState(stored.ringWidth);
-  const [font, setFont] = useState<StoredFont | null>(stored.font);
-  const [view, setView] = useState<'presets' | 'edit'>('presets');
+  const [fonts, setFonts] = useState<StoredFonts>(stored.fonts);
+  const [view, setView] = useState<View>('presets');
 
   const scheme = useMemo(
     () => SCHEMES.find((s) => s.id === schemeId) ?? DEFAULT_SCHEME,
     [schemeId]
   );
+
+  const activePairing = useMemo(() => findPairing(fonts), [fonts]);
 
   const apply = useCallback(() => {
     for (const token of COLOR_TOKENS) {
@@ -94,17 +117,23 @@ const DSConfig = () => {
     } else {
       removeRoot('--ring-width');
     }
-    if (font) {
-      document.body.style.fontFamily = `'${font.family}', ${fallbackFor(font.category)}`;
-    } else {
-      document.body.style.removeProperty('font-family');
+    for (const slot of FONT_SLOTS) {
+      const font = fonts[slot];
+      if (font) {
+        setRoot(FONT_VAR[slot], fontFamilyValue(font));
+      } else {
+        removeRoot(FONT_VAR[slot]);
+      }
     }
-  }, [scheme, overrides, radiusStep, ringWidth, font]);
+  }, [scheme, overrides, radiusStep, ringWidth, fonts]);
 
-  // Re-attach the <link> tag after Astro view transitions swap the document.
+  // Re-attach the <link> tags after Astro view transitions swap the document.
   useEffect(() => {
-    if (font) loadGoogleFont(font.family);
-  }, [font]);
+    for (const slot of FONT_SLOTS) {
+      const font = fonts[slot];
+      if (font) loadGoogleFont(font.family);
+    }
+  }, [fonts]);
 
   useEffect(() => {
     apply();
@@ -113,8 +142,8 @@ const DSConfig = () => {
   }, [apply]);
 
   useEffect(() => {
-    writeStored({ schemeId, overrides, radiusStep, ringWidth, font });
-  }, [schemeId, overrides, radiusStep, ringWidth, font]);
+    writeStored({ schemeId, overrides, radiusStep, ringWidth, fonts });
+  }, [schemeId, overrides, radiusStep, ringWidth, fonts]);
 
   const handleTokenChange = (
     token: ColorToken,
@@ -133,14 +162,29 @@ const DSConfig = () => {
     });
   };
 
+  const handleFontChange = (slot: FontSlot, next: StoredFont | null) => {
+    if (next) loadGoogleFont(next.family);
+    setFonts((prev) => ({ ...prev, [slot]: next }));
+  };
+
+  const handlePairingSelect = (pairing: Pairing) => {
+    for (const slot of FONT_SLOTS) {
+      const font = pairing.fonts[slot];
+      if (font) loadGoogleFont(font.family);
+    }
+    setFonts(pairing.fonts);
+  };
+
   const handleResetOverrides = () => setOverrides({});
+
+  const handleResetFonts = () => setFonts(EMPTY_FONTS);
 
   const handleReset = () => {
     setSchemeId(DEFAULT_SCHEME_ID);
     setOverrides({});
     setRadiusStep(RADIUS_DEFAULT);
     setRingWidth(RING_DEFAULT);
-    setFont(null);
+    setFonts(EMPTY_FONTS);
   };
 
   const generateCSSOverrides = () => {
@@ -156,22 +200,35 @@ const DSConfig = () => {
     if (ringWidth !== RING_DEFAULT) {
       tokenLines.push(`  --ring-width: ${ringWidth}px;`);
     }
-
-    const blocks: string[] = [];
-    if (tokenLines.length > 0) {
-      blocks.push(`:root {\n${tokenLines.join('\n')}\n}`);
-    }
-    if (font) {
-      blocks.push(
-        `body {\n  font-family: '${font.family}', ${fallbackFor(font.category)};\n}`
-      );
+    for (const slot of FONT_SLOTS) {
+      const font = fonts[slot];
+      if (!font) continue;
+      tokenLines.push(`  ${FONT_VAR[slot]}: ${fontFamilyValue(font)};`);
     }
 
-    if (blocks.length === 0) return '/* No customizations */';
-    return blocks.join('\n\n');
+    if (tokenLines.length === 0) return '/* No customizations */';
+    return `:root {\n${tokenLines.join('\n')}\n}`;
   };
 
-  const editing = view === 'edit';
+  const headerLabel: Record<View, string> = {
+    presets: 'Design system',
+    'edit-colors': 'Edit colors',
+    'edit-fonts': 'Edit fonts',
+  };
+
+  const headerReset: Record<View, () => void> = {
+    presets: handleReset,
+    'edit-colors': handleResetOverrides,
+    'edit-fonts': handleResetFonts,
+  };
+
+  const headerResetLabel: Record<View, string> = {
+    presets: 'Reset to defaults',
+    'edit-colors': 'Reset overrides',
+    'edit-fonts': 'Reset fonts',
+  };
+
+  const isEditing = view !== 'presets';
 
   return (
     <Popover placement="bottom-end">
@@ -186,7 +243,7 @@ const DSConfig = () => {
       </Popover.Trigger>
       <Popover.Content className="w-80 p-0">
         <div className="flex items-center gap-2 border-border border-b px-3 py-2">
-          {editing && (
+          {isEditing && (
             <IconButton
               variant="ghost"
               size="xs"
@@ -197,26 +254,32 @@ const DSConfig = () => {
             </IconButton>
           )}
           <span className="flex-1 font-medium text-sm">
-            {editing ? 'Edit colors' : 'Design system'}
+            {headerLabel[view]}
           </span>
           <IconButton
             variant="ghost"
             size="xs"
-            aria-label={editing ? 'Reset overrides' : 'Reset to defaults'}
-            onClick={editing ? handleResetOverrides : handleReset}
+            aria-label={headerResetLabel[view]}
+            onClick={headerReset[view]}
           >
             <ArrowCounterClockwiseIcon />
           </IconButton>
           <CopyButton content={generateCSSOverrides()} />
         </div>
 
-        {editing ? (
+        {view === 'edit-colors' && (
           <SchemeEditor
             scheme={scheme}
             overrides={overrides}
             onTokenChange={handleTokenChange}
           />
-        ) : (
+        )}
+
+        {view === 'edit-fonts' && (
+          <TypographyEditor fonts={fonts} onFontChange={handleFontChange} />
+        )}
+
+        {view === 'presets' && (
           <div className="flex flex-col divide-y divide-border">
             <div className="flex flex-col gap-2 p-3">
               <div className="flex items-center justify-between">
@@ -225,7 +288,7 @@ const DSConfig = () => {
                   variant="ghost"
                   size="xs"
                   aria-label="Edit colors"
-                  onClick={() => setView('edit')}
+                  onClick={() => setView('edit-colors')}
                 >
                   <PencilSimpleIcon />
                 </IconButton>
@@ -252,8 +315,30 @@ const DSConfig = () => {
             </div>
 
             <div className="flex flex-col gap-2 p-3">
-              <span className="font-medium text-xs">Typography</span>
-              <TypographyPicker value={font} onChange={setFont} />
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-xs">Typography</span>
+                <IconButton
+                  variant="ghost"
+                  size="xs"
+                  aria-label="Edit fonts"
+                  onClick={() => setView('edit-fonts')}
+                >
+                  <PencilSimpleIcon />
+                </IconButton>
+              </div>
+              <div className="grid grid-cols-3 gap-1.5">
+                {PAIRINGS.map((p) => {
+                  const isActive = activePairing?.id === p.id;
+                  return (
+                    <PairingTile
+                      key={p.id}
+                      pairing={p}
+                      isActive={isActive}
+                      onSelect={handlePairingSelect}
+                    />
+                  );
+                })}
+              </div>
             </div>
 
             <div className="flex flex-col gap-3 p-3">
@@ -316,6 +401,62 @@ const DSConfig = () => {
         </div>
       </Popover.Content>
     </Popover>
+  );
+};
+
+type PairingTileProps = {
+  pairing: Pairing;
+  isActive: boolean;
+  onSelect: (pairing: Pairing) => void;
+};
+
+const PairingTile = ({ pairing, isActive, onSelect }: PairingTileProps) => {
+  const headingFont = pairing.fonts.heading ?? pairing.fonts.body;
+  const bodyFont = pairing.fonts.body;
+
+  // Lazy-load preview fonts only when the popover is open.
+  useEffect(() => {
+    if (headingFont) loadGoogleFont(headingFont.family);
+    if (bodyFont) loadGoogleFont(bodyFont.family);
+  }, [headingFont, bodyFont]);
+
+  const headingFamily = headingFont
+    ? fontFamilyValue(headingFont)
+    : 'var(--font-heading)';
+  const bodyFamily = bodyFont ? fontFamilyValue(bodyFont) : 'var(--font-body)';
+
+  const tooltip =
+    pairing.id === DEFAULT_PAIRING.id
+      ? pairing.label
+      : [pairing.fonts.heading?.family, pairing.fonts.body?.family]
+          .filter(Boolean)
+          .join(' / ') || pairing.label;
+
+  return (
+    <button
+      type="button"
+      aria-label={pairing.label}
+      aria-pressed={isActive}
+      onClick={() => onSelect(pairing)}
+      title={tooltip}
+      data-active={isActive || undefined}
+      className="focus-visible:ring-(length:--ring-width) flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border border-border bg-background px-2 outline-none ring-ring transition hover:bg-background-secondary data-active:border-foreground"
+      style={{ opacity: isActive ? 1 : 0.6 }}
+    >
+      <span
+        aria-hidden="true"
+        className="font-semibold text-sm leading-none"
+        style={{ fontFamily: headingFamily }}
+      >
+        Aa
+      </span>
+      <span
+        className="text-2xs text-foreground-secondary leading-none"
+        style={{ fontFamily: bodyFamily }}
+      >
+        {pairing.label}
+      </span>
+    </button>
   );
 };
 

--- a/src/components/ds-config/ds-config.tsx
+++ b/src/components/ds-config/ds-config.tsx
@@ -4,11 +4,12 @@ import {
   PencilSimpleIcon,
   SlidersHorizontalIcon,
 } from '@phosphor-icons/react/dist/ssr';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { CopyButton } from '@/components/copy-button';
 import { IconButton } from '@/foundations/ui/button/button';
 import { Popover } from '@/foundations/ui/popover/popover';
 import { Slider } from '@/foundations/ui/slider/slider';
+import { Tooltip } from '@/foundations/ui/tooltip/tooltip';
 import {
   DEFAULT_PAIRING,
   findPairing,
@@ -68,10 +69,11 @@ const resolveToken = (
 const fontFamilyValue = (font: StoredFont) =>
   `'${font.family}', ${fallbackFor(font.category)}`;
 
-const FONT_SLOTS: FontSlot[] = ['heading', 'body', 'mono'];
+const FONT_SLOTS: FontSlot[] = ['heading', 'body', 'ui', 'mono'];
 const FONT_VAR: Record<FontSlot, string> = {
   heading: '--font-heading',
   body: '--font-body',
+  ui: '--font-ui',
   mono: '--font-mono',
 };
 
@@ -326,19 +328,21 @@ const DSConfig = () => {
                   <PencilSimpleIcon />
                 </IconButton>
               </div>
-              <div className="grid grid-cols-3 gap-1.5">
-                {PAIRINGS.map((p) => {
-                  const isActive = activePairing?.id === p.id;
-                  return (
-                    <PairingTile
-                      key={p.id}
-                      pairing={p}
-                      isActive={isActive}
-                      onSelect={handlePairingSelect}
-                    />
-                  );
-                })}
-              </div>
+              <Tooltip.Group>
+                <div className="grid grid-cols-3 gap-1.5">
+                  {PAIRINGS.map((p) => {
+                    const isActive = activePairing?.id === p.id;
+                    return (
+                      <PairingTile
+                        key={p.id}
+                        pairing={p}
+                        isActive={isActive}
+                        onSelect={handlePairingSelect}
+                      />
+                    );
+                  })}
+                </div>
+              </Tooltip.Group>
             </div>
 
             <div className="flex flex-col gap-3 p-3">
@@ -410,53 +414,82 @@ type PairingTileProps = {
   onSelect: (pairing: Pairing) => void;
 };
 
+const SLOT_LABELS: Record<FontSlot, string> = {
+  heading: 'Heading',
+  body: 'Body',
+  ui: 'UI',
+  mono: 'Mono',
+};
+
 const PairingTile = ({ pairing, isActive, onSelect }: PairingTileProps) => {
   const headingFont = pairing.fonts.heading ?? pairing.fonts.body;
-  const bodyFont = pairing.fonts.body;
+  const uiFont = pairing.fonts.ui ?? pairing.fonts.body;
 
   // Lazy-load preview fonts only when the popover is open.
   useEffect(() => {
     if (headingFont) loadGoogleFont(headingFont.family);
-    if (bodyFont) loadGoogleFont(bodyFont.family);
-  }, [headingFont, bodyFont]);
+    if (uiFont) loadGoogleFont(uiFont.family);
+  }, [headingFont, uiFont]);
 
   const headingFamily = headingFont
     ? fontFamilyValue(headingFont)
     : 'var(--font-heading)';
-  const bodyFamily = bodyFont ? fontFamilyValue(bodyFont) : 'var(--font-body)';
+  const uiFamily = uiFont ? fontFamilyValue(uiFont) : 'var(--font-ui)';
 
-  const tooltip =
-    pairing.id === DEFAULT_PAIRING.id
-      ? pairing.label
-      : [pairing.fonts.heading?.family, pairing.fonts.body?.family]
-          .filter(Boolean)
-          .join(' / ') || pairing.label;
+  const setSlots = FONT_SLOTS.filter((slot) => pairing.fonts[slot] !== null);
+  const isSystem = pairing.id === DEFAULT_PAIRING.id;
 
   return (
-    <button
-      type="button"
-      aria-label={pairing.label}
-      aria-pressed={isActive}
-      onClick={() => onSelect(pairing)}
-      title={tooltip}
-      data-active={isActive || undefined}
-      className="focus-visible:ring-(length:--ring-width) flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border border-border bg-background px-2 outline-none ring-ring transition hover:bg-background-secondary data-active:border-foreground"
-      style={{ opacity: isActive ? 1 : 0.6 }}
-    >
-      <span
-        aria-hidden="true"
-        className="font-semibold text-sm leading-none"
-        style={{ fontFamily: headingFamily }}
-      >
-        Aa
-      </span>
-      <span
-        className="text-2xs text-foreground-secondary leading-none"
-        style={{ fontFamily: bodyFamily }}
-      >
-        {pairing.label}
-      </span>
-    </button>
+    <Tooltip>
+      <Tooltip.Trigger asChild>
+        <button
+          type="button"
+          aria-label={pairing.label}
+          aria-pressed={isActive}
+          onClick={() => onSelect(pairing)}
+          data-active={isActive || undefined}
+          className="focus-visible:ring-(length:--ring-width) flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border border-border bg-background px-2 outline-none ring-ring transition hover:bg-background-secondary data-active:border-foreground"
+          style={{ opacity: isActive ? 1 : 0.6 }}
+        >
+          <span
+            aria-hidden="true"
+            className="font-semibold text-sm leading-none"
+            style={{ fontFamily: headingFamily }}
+          >
+            Aa
+          </span>
+          <span
+            className="text-2xs text-foreground-secondary leading-none"
+            style={{ fontFamily: uiFamily }}
+          >
+            {pairing.label}
+          </span>
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium">{pairing.label}</span>
+          {isSystem ? (
+            <span className="text-foreground-secondary">
+              Inherits your defaults
+            </span>
+          ) : (
+            <div className="grid grid-cols-[auto_1fr] gap-x-2 text-foreground-secondary">
+              {setSlots.map((slot) => {
+                const f = pairing.fonts[slot];
+                if (!f) return null;
+                return (
+                  <Fragment key={slot}>
+                    <span>{SLOT_LABELS[slot]}</span>
+                    <span className="text-foreground">{f.family}</span>
+                  </Fragment>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </Tooltip.Content>
+    </Tooltip>
   );
 };
 

--- a/src/components/ds-config/ds-config.tsx
+++ b/src/components/ds-config/ds-config.tsx
@@ -129,12 +129,17 @@ const DSConfig = () => {
     }
   }, [scheme, overrides, radiusStep, ringWidth, fonts]);
 
-  // Re-attach the <link> tags after Astro view transitions swap the document.
   useEffect(() => {
-    for (const slot of FONT_SLOTS) {
-      const font = fonts[slot];
-      if (font) loadGoogleFont(font.family);
-    }
+    const ensureFontsLoaded = () => {
+      for (const slot of FONT_SLOTS) {
+        const font = fonts[slot];
+        if (font) loadGoogleFont(font.family);
+      }
+    };
+    ensureFontsLoaded();
+    document.addEventListener('astro:after-swap', ensureFontsLoaded);
+    return () =>
+      document.removeEventListener('astro:after-swap', ensureFontsLoaded);
   }, [fonts]);
 
   useEffect(() => {

--- a/src/components/ds-config/ds-config.tsx
+++ b/src/components/ds-config/ds-config.tsx
@@ -4,7 +4,7 @@ import {
   PencilSimpleIcon,
   SlidersHorizontalIcon,
 } from '@phosphor-icons/react/dist/ssr';
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CopyButton } from '@/components/copy-button';
 import { IconButton } from '@/foundations/ui/button/button';
 import { Popover } from '@/foundations/ui/popover/popover';
@@ -248,7 +248,7 @@ const DSConfig = () => {
           <SlidersHorizontalIcon />
         </IconButton>
       </Popover.Trigger>
-      <Popover.Content className="w-80 p-0">
+      <Popover.Content className="w-80 p-0 pb-1">
         <div className="flex items-center gap-2 border-border border-b px-3 py-2">
           {isEditing && (
             <IconButton
@@ -401,13 +401,6 @@ const DSConfig = () => {
             </div>
           </div>
         )}
-
-        <div className="border-border border-t p-3">
-          <p className="text-foreground-secondary text-xs">
-            Copy the snippet and paste it into your project's CSS to apply this
-            configuration.
-          </p>
-        </div>
       </Popover.Content>
     </Popover>
   );
@@ -445,7 +438,7 @@ const PairingTile = ({ pairing, isActive, onSelect }: PairingTileProps) => {
   const isSystem = pairing.id === DEFAULT_PAIRING.id;
 
   return (
-    <Tooltip>
+    <Tooltip delayIn={1000}>
       <Tooltip.Trigger asChild>
         <button
           type="button"
@@ -453,8 +446,8 @@ const PairingTile = ({ pairing, isActive, onSelect }: PairingTileProps) => {
           aria-pressed={isActive}
           onClick={() => onSelect(pairing)}
           data-active={isActive || undefined}
-          className="focus-visible:ring-(length:--ring-width) flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border border-border bg-background px-2 outline-none ring-ring transition hover:bg-background-secondary data-active:border-foreground"
-          style={{ opacity: isActive ? 1 : 0.6 }}
+          className="focus-visible:ring-(length:--ring-width) flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border border-border bg-background px-2 outline-none ring-ring transition hover:bg-background-secondary"
+          style={{ opacity: isActive ? 1 : 0.5 }}
         >
           <span
             aria-hidden="true"
@@ -472,27 +465,27 @@ const PairingTile = ({ pairing, isActive, onSelect }: PairingTileProps) => {
         </button>
       </Tooltip.Trigger>
       <Tooltip.Content>
-        <div className="flex flex-col gap-1">
-          <span className="font-medium">{pairing.label}</span>
-          {isSystem ? (
-            <span className="text-foreground-secondary">
-              Inherits your defaults
-            </span>
-          ) : (
-            <div className="grid grid-cols-[auto_1fr] gap-x-2 text-foreground-secondary">
-              {setSlots.map((slot) => {
-                const f = pairing.fonts[slot];
-                if (!f) return null;
-                return (
-                  <Fragment key={slot}>
-                    <span>{SLOT_LABELS[slot]}</span>
-                    <span className="text-foreground">{f.family}</span>
-                  </Fragment>
-                );
-              })}
-            </div>
-          )}
-        </div>
+        {isSystem ? (
+          <span>Inherits your defaults</span>
+        ) : (
+          <div>
+            {setSlots.map((slot) => {
+              const f = pairing.fonts[slot];
+              if (!f) return null;
+              return (
+                <div
+                  key={slot}
+                  className="flex items-center justify-between gap-4"
+                >
+                  <span className="text-background">{f.family}</span>
+                  <span className="text-right text-background/50">
+                    {SLOT_LABELS[slot]}{' '}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </Tooltip.Content>
     </Tooltip>
   );

--- a/src/components/ds-config/pairings.ts
+++ b/src/components/ds-config/pairings.ts
@@ -14,57 +14,76 @@ const font = (
   category,
 });
 
+const empty: StoredFonts = {
+  heading: null,
+  body: null,
+  ui: null,
+  mono: null,
+};
+
 export const DEFAULT_PAIRING_ID = 'default';
 
 export const PAIRINGS: Pairing[] = [
   {
     id: 'default',
     label: 'System',
-    fonts: { heading: null, body: null, mono: null },
+    fonts: { ...empty },
   },
+  // Full 3-font editorial: display serif headings, transitional serif body
+  // for prose, neo-grotesque sans for chrome. Magazine / publication mood.
   {
     id: 'editorial',
     label: 'Editorial',
     fonts: {
       heading: font('Playfair Display', 'serif'),
-      body: font('Inter', 'sans-serif'),
+      body: font('Source Serif 4', 'serif'),
+      ui: font('Inter', 'sans-serif'),
       mono: null,
     },
   },
+  // Warm humanist serif for prose + headings, clean sans chrome.
+  // Education, healthcare, anything wanting friendliness without losing voice.
   {
     id: 'humanist',
     label: 'Humanist',
     fonts: {
       heading: font('Lora', 'serif'),
-      body: font('Inter', 'sans-serif'),
+      body: font('Lora', 'serif'),
+      ui: font('Inter', 'sans-serif'),
       mono: null,
     },
   },
+  // Single-face modernist geometric sans. Swiss, clean, opinionated.
   {
-    id: 'geometric',
-    label: 'Geometric',
+    id: 'modernist',
+    label: 'Modernist',
     fonts: {
-      heading: font('Manrope', 'sans-serif'),
-      body: font('Manrope', 'sans-serif'),
+      heading: null,
+      body: font('Outfit', 'sans-serif'),
+      ui: null,
       mono: null,
     },
   },
+  // Industrial body + matching typewriter mono. Studio / agency / raw.
   {
-    id: 'tech',
-    label: 'Tech',
+    id: 'brutalist',
+    label: 'Brutalist',
     fonts: {
-      heading: font('Geist', 'sans-serif'),
+      heading: null,
+      body: font('Space Grotesk', 'sans-serif'),
+      ui: null,
+      mono: font('Space Mono', 'monospace'),
+    },
+  },
+  // Modern tech-brand: paired sans + mono designed as a family.
+  {
+    id: 'geist',
+    label: 'Geist',
+    fonts: {
+      heading: null,
       body: font('Geist', 'sans-serif'),
+      ui: null,
       mono: font('Geist Mono', 'monospace'),
-    },
-  },
-  {
-    id: 'plex',
-    label: 'Plex',
-    fonts: {
-      heading: font('IBM Plex Sans', 'sans-serif'),
-      body: font('IBM Plex Sans', 'sans-serif'),
-      mono: font('IBM Plex Mono', 'monospace'),
     },
   },
 ];
@@ -77,6 +96,7 @@ const sameFont = (a: StoredFont | null, b: StoredFont | null) =>
 export const fontsEqual = (a: StoredFonts, b: StoredFonts) =>
   sameFont(a.heading, b.heading) &&
   sameFont(a.body, b.body) &&
+  sameFont(a.ui, b.ui) &&
   sameFont(a.mono, b.mono);
 
 export const findPairing = (fonts: StoredFonts): Pairing | null =>

--- a/src/components/ds-config/pairings.ts
+++ b/src/components/ds-config/pairings.ts
@@ -1,0 +1,83 @@
+import type { StoredFont, StoredFonts } from './storage';
+
+export type Pairing = {
+  id: string;
+  label: string;
+  fonts: StoredFonts;
+};
+
+const font = (
+  family: string,
+  category: StoredFont['category']
+): StoredFont => ({
+  family,
+  category,
+});
+
+export const DEFAULT_PAIRING_ID = 'default';
+
+export const PAIRINGS: Pairing[] = [
+  {
+    id: 'default',
+    label: 'System',
+    fonts: { heading: null, body: null, mono: null },
+  },
+  {
+    id: 'editorial',
+    label: 'Editorial',
+    fonts: {
+      heading: font('Playfair Display', 'serif'),
+      body: font('Inter', 'sans-serif'),
+      mono: null,
+    },
+  },
+  {
+    id: 'humanist',
+    label: 'Humanist',
+    fonts: {
+      heading: font('Lora', 'serif'),
+      body: font('Inter', 'sans-serif'),
+      mono: null,
+    },
+  },
+  {
+    id: 'geometric',
+    label: 'Geometric',
+    fonts: {
+      heading: font('Manrope', 'sans-serif'),
+      body: font('Manrope', 'sans-serif'),
+      mono: null,
+    },
+  },
+  {
+    id: 'tech',
+    label: 'Tech',
+    fonts: {
+      heading: font('Geist', 'sans-serif'),
+      body: font('Geist', 'sans-serif'),
+      mono: font('Geist Mono', 'monospace'),
+    },
+  },
+  {
+    id: 'plex',
+    label: 'Plex',
+    fonts: {
+      heading: font('IBM Plex Sans', 'sans-serif'),
+      body: font('IBM Plex Sans', 'sans-serif'),
+      mono: font('IBM Plex Mono', 'monospace'),
+    },
+  },
+];
+
+export const DEFAULT_PAIRING: Pairing = PAIRINGS[0];
+
+const sameFont = (a: StoredFont | null, b: StoredFont | null) =>
+  (a?.family ?? null) === (b?.family ?? null);
+
+export const fontsEqual = (a: StoredFonts, b: StoredFonts) =>
+  sameFont(a.heading, b.heading) &&
+  sameFont(a.body, b.body) &&
+  sameFont(a.mono, b.mono);
+
+export const findPairing = (fonts: StoredFonts): Pairing | null =>
+  PAIRINGS.find((p) => fontsEqual(p.fonts, fonts)) ?? null;

--- a/src/components/ds-config/storage.ts
+++ b/src/components/ds-config/storage.ts
@@ -18,12 +18,22 @@ export type FontCategory =
 
 export type StoredFont = { family: string; category: FontCategory };
 
+export type FontSlot = 'heading' | 'body' | 'mono';
+
+export type StoredFonts = Record<FontSlot, StoredFont | null>;
+
+export const EMPTY_FONTS: StoredFonts = {
+  heading: null,
+  body: null,
+  mono: null,
+};
+
 export type StoredConfig = {
   schemeId: string;
   overrides: Partial<Record<ColorToken, TokenValues>>;
   radiusStep: number;
   ringWidth: number;
-  font: StoredFont | null;
+  fonts: StoredFonts;
 };
 
 export const DEFAULT_STORED_CONFIG: StoredConfig = {
@@ -31,7 +41,7 @@ export const DEFAULT_STORED_CONFIG: StoredConfig = {
   overrides: {},
   radiusStep: RADIUS_DEFAULT,
   ringWidth: RING_DEFAULT,
-  font: null,
+  fonts: EMPTY_FONTS,
 };
 
 // Pre-schemes shape: { accent: 'Blue', radiusStep, ringWidth }.
@@ -39,6 +49,15 @@ type LegacyConfig = {
   accent: string;
   radiusStep?: number;
   ringWidth?: number;
+};
+
+// Single-font shape that preceded the heading/body/mono triple.
+type SingleFontConfig = {
+  schemeId: string;
+  overrides: Partial<Record<ColorToken, TokenValues>>;
+  radiusStep: number;
+  ringWidth: number;
+  font: StoredFont | null;
 };
 
 const LEGACY_LABEL_TO_SCHEME_ID: Record<string, string> = {
@@ -58,6 +77,13 @@ const isLegacy = (raw: unknown): raw is LegacyConfig =>
   'accent' in raw &&
   !('schemeId' in raw);
 
+const isSingleFont = (raw: unknown): raw is SingleFontConfig =>
+  typeof raw === 'object' &&
+  raw !== null &&
+  'schemeId' in raw &&
+  'font' in raw &&
+  !('fonts' in raw);
+
 export const readStored = (): StoredConfig => {
   if (typeof window === 'undefined') return DEFAULT_STORED_CONFIG;
   try {
@@ -70,10 +96,24 @@ export const readStored = (): StoredConfig => {
         overrides: {},
         radiusStep: parsed.radiusStep ?? RADIUS_DEFAULT,
         ringWidth: parsed.ringWidth ?? RING_DEFAULT,
-        font: null,
+        fonts: EMPTY_FONTS,
       };
     }
-    return { ...DEFAULT_STORED_CONFIG, ...(parsed as Partial<StoredConfig>) };
+    if (isSingleFont(parsed)) {
+      return {
+        schemeId: parsed.schemeId,
+        overrides: parsed.overrides,
+        radiusStep: parsed.radiusStep,
+        ringWidth: parsed.ringWidth,
+        fonts: { heading: null, body: parsed.font, mono: null },
+      };
+    }
+    const next = parsed as Partial<StoredConfig>;
+    return {
+      ...DEFAULT_STORED_CONFIG,
+      ...next,
+      fonts: { ...EMPTY_FONTS, ...(next.fonts ?? {}) },
+    };
   } catch {
     return DEFAULT_STORED_CONFIG;
   }

--- a/src/components/ds-config/storage.ts
+++ b/src/components/ds-config/storage.ts
@@ -18,13 +18,14 @@ export type FontCategory =
 
 export type StoredFont = { family: string; category: FontCategory };
 
-export type FontSlot = 'heading' | 'body' | 'mono';
+export type FontSlot = 'heading' | 'body' | 'ui' | 'mono';
 
 export type StoredFonts = Record<FontSlot, StoredFont | null>;
 
 export const EMPTY_FONTS: StoredFonts = {
   heading: null,
   body: null,
+  ui: null,
   mono: null,
 };
 
@@ -105,7 +106,7 @@ export const readStored = (): StoredConfig => {
         overrides: parsed.overrides,
         radiusStep: parsed.radiusStep,
         ringWidth: parsed.ringWidth,
-        fonts: { heading: null, body: parsed.font, mono: null },
+        fonts: { ...EMPTY_FONTS, body: parsed.font },
       };
     }
     const next = parsed as Partial<StoredConfig>;

--- a/src/components/ds-config/typography-editor.tsx
+++ b/src/components/ds-config/typography-editor.tsx
@@ -26,9 +26,16 @@ const SLOTS: SlotConfig[] = [
   {
     slot: 'body',
     label: 'Body',
-    hint: 'Used for body text and UI chrome (buttons, badges, inputs).',
+    hint: 'Used for prose. Default for UI chrome unless UI is set.',
     placeholder: 'System default',
     nullLabel: 'System default',
+  },
+  {
+    slot: 'ui',
+    label: 'UI',
+    hint: 'Used for chrome (buttons, inputs, menus). Falls back to body.',
+    placeholder: 'Inherit body',
+    nullLabel: 'Inherit body',
   },
   {
     slot: 'mono',

--- a/src/components/ds-config/typography-editor.tsx
+++ b/src/components/ds-config/typography-editor.tsx
@@ -1,0 +1,68 @@
+import type {
+  FontCategory,
+  FontSlot,
+  StoredFont,
+  StoredFonts,
+} from './storage';
+import { TypographyPicker } from './typography-picker';
+
+type SlotConfig = {
+  slot: FontSlot;
+  label: string;
+  hint: string;
+  placeholder: string;
+  nullLabel: string;
+  category?: FontCategory;
+};
+
+const SLOTS: SlotConfig[] = [
+  {
+    slot: 'heading',
+    label: 'Heading',
+    hint: 'Used for headings (h1–h6).',
+    placeholder: 'Inherit body',
+    nullLabel: 'Inherit body',
+  },
+  {
+    slot: 'body',
+    label: 'Body',
+    hint: 'Used for body text and UI chrome (buttons, badges, inputs).',
+    placeholder: 'System default',
+    nullLabel: 'System default',
+  },
+  {
+    slot: 'mono',
+    label: 'Mono',
+    hint: 'Used for code blocks, kbd, and tabular numerics.',
+    placeholder: 'System monospace',
+    nullLabel: 'System monospace',
+    category: 'monospace',
+  },
+];
+
+type TypographyEditorProps = {
+  fonts: StoredFonts;
+  onFontChange: (slot: FontSlot, value: StoredFont | null) => void;
+};
+
+const TypographyEditor = ({ fonts, onFontChange }: TypographyEditorProps) => {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      {SLOTS.map((cfg) => (
+        <div key={cfg.slot} className="flex flex-col gap-1">
+          <span className="font-medium text-xs">{cfg.label}</span>
+          <TypographyPicker
+            value={fonts[cfg.slot]}
+            onChange={(next) => onFontChange(cfg.slot, next)}
+            placeholder={cfg.placeholder}
+            nullLabel={cfg.nullLabel}
+            category={cfg.category}
+          />
+          <span className="text-2xs text-foreground-secondary">{cfg.hint}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export { TypographyEditor };

--- a/src/components/ds-config/typography-picker.tsx
+++ b/src/components/ds-config/typography-picker.tsx
@@ -1,20 +1,45 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { Listbox } from '@/foundations/ui/listbox/listbox';
-import type { StoredFont } from './storage';
+import type { FontCategory, StoredFont } from './storage';
 import {
   type FontMeta,
   fetchCatalog,
   loadGoogleFont,
 } from './use-fonts-catalog';
 
-const FEATURED: FontMeta[] = [
-  { family: 'Inter', category: 'sans-serif' },
-  { family: 'Geist', category: 'sans-serif' },
-  { family: 'IBM Plex Sans', category: 'sans-serif' },
-  { family: 'Manrope', category: 'sans-serif' },
-  { family: 'Lora', category: 'serif' },
-  { family: 'Space Mono', category: 'monospace' },
+const FEATURED_BY_CATEGORY: Record<FontCategory, FontMeta[]> = {
+  'sans-serif': [
+    { family: 'Inter', category: 'sans-serif' },
+    { family: 'Geist', category: 'sans-serif' },
+    { family: 'IBM Plex Sans', category: 'sans-serif' },
+    { family: 'Manrope', category: 'sans-serif' },
+    { family: 'Outfit', category: 'sans-serif' },
+    { family: 'Work Sans', category: 'sans-serif' },
+  ],
+  serif: [
+    { family: 'Playfair Display', category: 'serif' },
+    { family: 'Lora', category: 'serif' },
+    { family: 'EB Garamond', category: 'serif' },
+    { family: 'Source Serif 4', category: 'serif' },
+  ],
+  monospace: [
+    { family: 'Geist Mono', category: 'monospace' },
+    { family: 'IBM Plex Mono', category: 'monospace' },
+    { family: 'JetBrains Mono', category: 'monospace' },
+    { family: 'Space Mono', category: 'monospace' },
+  ],
+  display: [
+    { family: 'Playfair Display', category: 'serif' },
+    { family: 'Bricolage Grotesque', category: 'sans-serif' },
+  ],
+  handwriting: [],
+};
+
+const DEFAULT_FEATURED: FontMeta[] = [
+  ...FEATURED_BY_CATEGORY['sans-serif'].slice(0, 3),
+  ...FEATURED_BY_CATEGORY.serif.slice(0, 2),
+  ...FEATURED_BY_CATEGORY.monospace.slice(0, 1),
 ];
 
 const MAX_RESULTS = 100;
@@ -22,23 +47,34 @@ const MAX_RESULTS = 100;
 interface TypographyPickerProps {
   value: StoredFont | null;
   onChange: (value: StoredFont | null) => void;
+  placeholder?: string;
+  nullLabel?: string;
+  /** When set, featured + filter results are scoped to this category. */
+  category?: FontCategory;
 }
 
-const TypographyPicker = ({ value, onChange }: TypographyPickerProps) => {
+const TypographyPicker = ({
+  value,
+  onChange,
+  placeholder = 'System default',
+  nullLabel = 'System default',
+  category,
+}: TypographyPickerProps) => {
   const [search, setSearch] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  const featuredWithCurrent = useMemo<FontMeta[]>(() => {
-    if (!value) return FEATURED;
-    if (FEATURED.some((f) => f.family === value.family)) return FEATURED;
-    return [value, ...FEATURED];
-  }, [value]);
+  const featured = useMemo<FontMeta[]>(() => {
+    const base = category ? FEATURED_BY_CATEGORY[category] : DEFAULT_FEATURED;
+    if (!value) return base;
+    if (base.some((f) => f.family === value.family)) return base;
+    return [value, ...base];
+  }, [value, category]);
 
-  const [results, setResults] = useState<FontMeta[]>(featuredWithCurrent);
+  const [results, setResults] = useState<FontMeta[]>(featured);
 
   useEffect(() => {
     if (!search) {
-      setResults(featuredWithCurrent);
+      setResults(featured);
       setIsLoading(false);
       return;
     }
@@ -55,6 +91,7 @@ const TypographyPicker = ({ value, onChange }: TypographyPickerProps) => {
 
       setResults(
         catalog
+          .filter((font) => (category ? font.category === category : true))
           .filter((font) => font.family.toLowerCase().includes(query))
           .slice(0, MAX_RESULTS)
       );
@@ -66,7 +103,7 @@ const TypographyPicker = ({ value, onChange }: TypographyPickerProps) => {
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [search, featuredWithCurrent]);
+  }, [search, featured, category]);
 
   const handleSelect = (next: StoredFont | null) => {
     if (next) loadGoogleFont(next.family);
@@ -79,7 +116,7 @@ const TypographyPicker = ({ value, onChange }: TypographyPickerProps) => {
       onChange={handleSelect}
       getIsSelected={(a, b) => (a?.family ?? null) === (b?.family ?? null)}
     >
-      <Listbox.Trigger placeholder="System default">
+      <Listbox.Trigger placeholder={placeholder}>
         {value?.family}
       </Listbox.Trigger>
       <Listbox.Options>
@@ -91,7 +128,7 @@ const TypographyPicker = ({ value, onChange }: TypographyPickerProps) => {
         />
         {!search && (
           <>
-            <Listbox.Option value={null}>System default</Listbox.Option>
+            <Listbox.Option value={null}>{nullLabel}</Listbox.Option>
             <Listbox.Divider />
           </>
         )}

--- a/src/components/ds-config/use-fonts-catalog.ts
+++ b/src/components/ds-config/use-fonts-catalog.ts
@@ -13,7 +13,6 @@ const KNOWN_CATEGORIES: ReadonlySet<string> = new Set([
 const isFontCategory = (value: string): value is FontCategory =>
   KNOWN_CATEGORIES.has(value);
 
-const loaded = new Set<string>();
 let catalogPromise: Promise<FontMeta[]> | null = null;
 
 type CatalogRow = {
@@ -45,11 +44,15 @@ const familyToUrlParam = (family: string) =>
   encodeURIComponent(family).replace(/%20/g, '+');
 
 export const loadGoogleFont = (family: string) => {
-  if (loaded.has(family)) return;
-  loaded.add(family);
+  const href = `https://fonts.googleapis.com/css2?family=${familyToUrlParam(family)}:wght@400;500;600;700&display=swap`;
+  // Query the DOM rather than a module-level Set: Astro's ClientRouter swaps
+  // the page <head> on navigation and drops runtime-injected <link> tags. A
+  // Set would keep claiming a font is loaded when its <link> has already been
+  // removed, so subsequent pages would render in fallback fonts.
+  if (document.querySelector(`link[rel="stylesheet"][href="${href}"]`)) return;
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = `https://fonts.googleapis.com/css2?family=${familyToUrlParam(family)}:wght@400;500;600;700&display=swap`;
+  link.href = href;
   document.head.appendChild(link);
 };
 

--- a/src/foundations/changelog/page.mdx
+++ b/src/foundations/changelog/page.mdx
@@ -12,7 +12,7 @@ meta:
 
 ### Fixed: `Tooltip` stacks above an open `Popover`
 
-A `Tooltip` rendered inside a `Popover` (or any `popover="manual"` container) used to render *behind* the popover instead of above it. Root cause was in `useTopLayer`: the hook ran in `useLayoutEffect`, but `<FloatingPortal>` doesn't have its target element in the DOM on the first render — the portal node is created in an effect, the element mounts on the *second* render, and by then the layout effect had already run with `ref.current === null`. Result: `showPopover()` was never called for the tooltip, so the tooltip wasn't in the top layer, and the popover (which *was*) painted above it.
+A `Tooltip` rendered inside a `Popover` (or any `popover="manual"` container) used to render _behind_ the popover instead of above it. Root cause was in `useTopLayer`: the hook ran in `useLayoutEffect`, but `<FloatingPortal>` doesn't have its target element in the DOM on the first render — the portal node is created in an effect, the element mounts on the _second_ render, and by then the layout effect had already run with `ref.current === null`. Result: `showPopover()` was never called for the tooltip, so the tooltip wasn't in the top layer, and the popover (which _was_) painted above it.
 
 Two fixes:
 
@@ -35,19 +35,28 @@ Two fixes:
 + return <div ref={composeRefs(elementRef, topLayerRef)}>…</div>;
 ```
 
-### Semantic typography tokens
+### Changed: Semantic typography tokens
 
-The single `--font-sans` token is gone. In its place: four semantic roles — `--font-body`, `--font-ui`, `--font-heading`, and `--font-mono`.
+We introduce four semantic typography tokens covering the roles a brand actually pairs:
 
-`--font-body` is the canonical default. `--font-ui` (chrome — buttons, inputs, menus, badges, tooltips, modal/drawer titles) and `--font-heading` (h1–h6) both fall back to body, so brands that ship one face for everything still set one variable. Brands pairing a serif heading with a serif body and sans chrome — the editorial pattern — set all three. Markdown prose opts into `--font-body`; markdown headings opt into `--font-heading`; the body element uses `--font-ui`. Consumers using the old `font-sans` Tailwind utility need to swap to `font-body`.
+- `--font-ui` — UI chrome (buttons, inputs, menus, badges, tooltips, modal/drawer titles); the render default, applied via inheritance from `body`.
+- `--font-body` — body text (prose, paragraphs); opted into in strategic places like markdown.
+- `--font-heading` — h1–h6.
+- `--font-mono` — code, kbd, tabular numerics.
+
+`--font-ui` and `--font-heading` both default to `var(--font-body)`, so a brand shipping one face sets `--font-body` once and the rest cascades through. The editorial pattern (display heading + serif body + sans chrome) sets all three.
+
+The mechanism, without retrofitting every primitive: components pick up `--font-ui` automatically via inheritance, and prose/headings opt UP into their own tokens. When a brand differentiates them, the chrome font (the "standard" one) ends up most prevalent — exactly what you want when pairing a serif body with a sans for chrome.
+
+Consumers using the old `font-sans` Tailwind utility need to swap to `font-body`.
 
 ```diff css
 @theme {
-- --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, …;
-+ --font-body: "Inter", ui-sans-serif, system-ui, sans-serif, …;
+- --font-sans: ui-sans-serif, system-ui, sans-serif;
++ --font-body: ui-sans-serif, system-ui, sans-serif;
 + --font-ui: var(--font-body);
 + --font-heading: var(--font-body);
-  --font-mono: "Geist Mono", ui-monospace, monospace;
+  --font-mono: ui-monospace, monospace;
 }
 ```
 
@@ -58,7 +67,7 @@ body {
 }
 ```
 
-### `isLoading` on search inputs
+### Added: `isLoading` on search inputs
 
 `Popover.SearchInput` now accepts an `isLoading` prop. When true, the leading magnifying-glass icon is replaced with a spinner. `Listbox.SearchInput` and `Menu.SearchInput` forward the prop, so the same flag works everywhere a search field is rendered. Useful for async-filtered lists where the user types and the options are fetched.
 

--- a/src/foundations/changelog/page.mdx
+++ b/src/foundations/changelog/page.mdx
@@ -10,6 +10,31 @@ meta:
 
 ## May 2026
 
+### Fixed: `Tooltip` stacks above an open `Popover`
+
+A `Tooltip` rendered inside a `Popover` (or any `popover="manual"` container) used to render *behind* the popover instead of above it. Root cause was in `useTopLayer`: the hook ran in `useLayoutEffect`, but `<FloatingPortal>` doesn't have its target element in the DOM on the first render — the portal node is created in an effect, the element mounts on the *second* render, and by then the layout effect had already run with `ref.current === null`. Result: `showPopover()` was never called for the tooltip, so the tooltip wasn't in the top layer, and the popover (which *was*) painted above it.
+
+Two fixes:
+
+1. `useTopLayer` now returns a callback ref instead of a ref object, so the popover state is set whenever the element attaches — regardless of how many render passes the consumer's wrappers take. If you also need imperative access to the element, compose this ref with your own `useRef` via `composeRefs`.
+2. `Tooltip.Content` opts into `popover="hint"`. Per the Popover API, hints stack above other popovers without dismissing them — the right semantic for a tooltip.
+
+```diff ts
+- const ref = useTopLayer<HTMLDivElement>(isOpen);
++ const ref = useTopLayer<HTMLDivElement>(isOpen, 'hint'); // for tooltip-style elements
+```
+
+```diff tsx
+// If you previously read `ref.current` inside the hook's caller:
+- const ref = useTopLayer<HTMLDivElement>(true);
+- useEffect(() => { ref.current?.togglePopover(); }, []);
+- return <div ref={ref}>…</div>;
++ const elementRef = useRef<HTMLDivElement>(null);
++ const topLayerRef = useTopLayer<HTMLDivElement>(true);
++ useEffect(() => { elementRef.current?.togglePopover(); }, []);
++ return <div ref={composeRefs(elementRef, topLayerRef)}>…</div>;
+```
+
 ### Semantic typography tokens
 
 The single `--font-sans` token is gone. In its place: four semantic roles — `--font-body`, `--font-ui`, `--font-heading`, and `--font-mono`.

--- a/src/foundations/changelog/page.mdx
+++ b/src/foundations/changelog/page.mdx
@@ -10,6 +10,32 @@ meta:
 
 ## May 2026
 
+### Semantic typography tokens
+
+The single `--font-sans` token is gone. In its place: three semantic tokens — `--font-heading`, `--font-body`, and `--font-mono`. `--font-heading` falls back to `--font-body`, so brands that ship one face for everything still set one variable. Brands pairing a serif heading with a sans body now have the right opt-in: headings read `--font-heading`, everything else (Button, Badge, Input, Tooltip, Menu, modal/drawer titles) inherits body. Markdown headings (`h1`–`h6`) opt into `--font-heading`. Consumers using the old `font-sans` Tailwind utility need to swap to `font-body`.
+
+```diff css
+@theme {
+- --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, …;
++ --font-body: "Inter", ui-sans-serif, system-ui, sans-serif, …;
++ --font-heading: var(--font-body);
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+}
+```
+
+```diff css
+body {
+- font-family: var(--font-sans);
++ font-family: var(--font-body);
+}
+```
+
+```diff css
+/* markdown.css — h1..h6 */
+- @apply mt-[2em] mb-[1em] font-semibold tracking-tight;
++ @apply mt-[2em] mb-[1em] font-heading font-semibold tracking-tight;
+```
+
 ### `isLoading` on search inputs
 
 `Popover.SearchInput` now accepts an `isLoading` prop. When true, the leading magnifying-glass icon is replaced with a spinner. `Listbox.SearchInput` and `Menu.SearchInput` forward the prop, so the same flag works everywhere a search field is rendered. Useful for async-filtered lists where the user types and the options are fetched.

--- a/src/foundations/changelog/page.mdx
+++ b/src/foundations/changelog/page.mdx
@@ -12,12 +12,15 @@ meta:
 
 ### Semantic typography tokens
 
-The single `--font-sans` token is gone. In its place: three semantic tokens — `--font-heading`, `--font-body`, and `--font-mono`. `--font-heading` falls back to `--font-body`, so brands that ship one face for everything still set one variable. Brands pairing a serif heading with a sans body now have the right opt-in: headings read `--font-heading`, everything else (Button, Badge, Input, Tooltip, Menu, modal/drawer titles) inherits body. Markdown headings (`h1`–`h6`) opt into `--font-heading`. Consumers using the old `font-sans` Tailwind utility need to swap to `font-body`.
+The single `--font-sans` token is gone. In its place: four semantic roles — `--font-body`, `--font-ui`, `--font-heading`, and `--font-mono`.
+
+`--font-body` is the canonical default. `--font-ui` (chrome — buttons, inputs, menus, badges, tooltips, modal/drawer titles) and `--font-heading` (h1–h6) both fall back to body, so brands that ship one face for everything still set one variable. Brands pairing a serif heading with a serif body and sans chrome — the editorial pattern — set all three. Markdown prose opts into `--font-body`; markdown headings opt into `--font-heading`; the body element uses `--font-ui`. Consumers using the old `font-sans` Tailwind utility need to swap to `font-body`.
 
 ```diff css
 @theme {
 - --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, …;
 + --font-body: "Inter", ui-sans-serif, system-ui, sans-serif, …;
++ --font-ui: var(--font-body);
 + --font-heading: var(--font-body);
   --font-mono: "Geist Mono", ui-monospace, monospace;
 }
@@ -26,14 +29,8 @@ The single `--font-sans` token is gone. In its place: three semantic tokens — 
 ```diff css
 body {
 - font-family: var(--font-sans);
-+ font-family: var(--font-body);
++ font-family: var(--font-ui);
 }
-```
-
-```diff css
-/* markdown.css — h1..h6 */
-- @apply mt-[2em] mb-[1em] font-semibold tracking-tight;
-+ @apply mt-[2em] mb-[1em] font-heading font-semibold tracking-tight;
 ```
 
 ### `isLoading` on search inputs
@@ -218,7 +215,7 @@ const [pos, setPos] = useState<[number, number] | null>(null);
 A small hook for global keyboard shortcuts. `mod: true` is the cross-platform modifier — ⌘ on macOS, Ctrl elsewhere — which is what you almost always want for app-level commands like ⌘K.
 
 ```ts
-useKeyboardShortcut({ key: 'k', mod: true }, () => setOpen(true));
+useKeyboardShortcut({ key: "k", mod: true }, () => setOpen(true));
 ```
 
 ### Fixed: `Dropdown.Divider` and `Listbox.Divider` vertical spacing not tracking `--inset`

--- a/src/foundations/hooks/use-top-layer/page.mdx
+++ b/src/foundations/hooks/use-top-layer/page.mdx
@@ -22,10 +22,16 @@ folder: hooks
       type: "boolean",
       description: "Whether the element should be pushed to the Top Layer. Defaults to true.",
     },
+    type: {
+      name: "type",
+      type: '"manual" | "hint"',
+      description:
+        'Popover semantics. `manual` (default) is an independent popover that stays open until closed. `hint` is a tooltip-style popover that always stacks above other popovers without dismissing them — use it for tooltips that should float above an already-open `popover="manual"` (e.g. an open dropdown panel).',
+    },
   }}
 />
 
-The hook returns a `RefObject<T | null>` that should be attached to the target HTML element.
+The hook returns a `RefCallback<T>` that should be attached to the target HTML element. If you also need imperative access to the element, compose this ref with your own `useRef` via `composeRefs`.
 
 ## Examples
 

--- a/src/foundations/hooks/use-top-layer/use-top-layer.ts
+++ b/src/foundations/hooks/use-top-layer/use-top-layer.ts
@@ -1,7 +1,47 @@
-import { useLayoutEffect, useRef } from 'react';
+import { type RefCallback, useCallback, useRef } from 'react';
+
+type PopoverType = 'manual' | 'hint';
+
+const showAsPopover = <T extends HTMLElement>(
+  element: T,
+  type: PopoverType
+) => {
+  element.setAttribute('popover', type);
+  try {
+    element.showPopover();
+  } catch {
+    // already showing — ignored
+  }
+};
+
+const hideAsPopover = <T extends HTMLElement>(element: T) => {
+  try {
+    element.hidePopover();
+  } catch {
+    // already hidden / not connected — ignored
+  }
+  element.removeAttribute('popover');
+};
 
 /**
  * Custom hook to push an element to the application's Top Layer.
+ *
+ * `type` controls the popover semantics:
+ * - `manual` (default): independent popover that stays open until closed.
+ * - `hint`: tooltip-style popover that always stacks above other popovers
+ *   without dismissing them. Use this for tooltips so they float above an
+ *   already-open `popover="manual"` (e.g. an open dropdown panel).
+ *
+ * Returns a callback ref. We intentionally don't use `useLayoutEffect`
+ * because some floating-ui consumers (notably `<FloatingPortal>`) don't have
+ * their target element in the DOM on the first render — the portal node is
+ * created in an effect, the element mounts on the *second* render, and a
+ * layout effect would have already fired by then with a null ref. A callback
+ * ref activates the moment the element attaches, regardless of how many
+ * render passes the consumer's wrappers take.
+ *
+ * If you also need imperative access to the element, compose this ref with
+ * your own `useRef` via `composeRefs`.
  *
  *  @example
  * ```tsx
@@ -10,23 +50,20 @@ import { useLayoutEffect, useRef } from 'react';
  * ```
  */
 export const useTopLayer = <T extends HTMLElement>(
-  active: boolean = true
-): React.RefObject<T | null> => {
-  const ref = useRef<T>(null);
+  active: boolean = true,
+  type: PopoverType = 'manual'
+): RefCallback<T> => {
+  const previousRef = useRef<T | null>(null);
 
-  useLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) return;
+  return useCallback(
+    (element: T | null) => {
+      const previous = previousRef.current;
+      if (previous && previous !== element) hideAsPopover(previous);
 
-    if (active) {
-      element.setAttribute('popover', 'manual');
-      element.showPopover();
-    }
+      previousRef.current = element;
 
-    return () => {
-      element.removeAttribute('popover');
-    };
-  }, [active]);
-
-  return ref;
+      if (element && active) showAsPopover(element, type);
+    },
+    [active, type]
+  );
 };

--- a/src/foundations/setup/globals-data-attr.css
+++ b/src/foundations/setup/globals-data-attr.css
@@ -132,7 +132,7 @@
 body {
   scrollbar-gutter: stable;
 
-  font-family: var(--font-body);
+  font-family: var(--font-ui);
 
   background-color: var(--color-background);
   color: var(--color-foreground);

--- a/src/foundations/setup/globals-data-attr.css
+++ b/src/foundations/setup/globals-data-attr.css
@@ -132,7 +132,7 @@
 body {
   scrollbar-gutter: stable;
 
-  font-family: var(--font-sans);
+  font-family: var(--font-body);
 
   background-color: var(--color-background);
   color: var(--color-foreground);

--- a/src/foundations/setup/globals-prefers-schema.css
+++ b/src/foundations/setup/globals-prefers-schema.css
@@ -103,7 +103,7 @@
 }
 
 body {
-  font-family: var(--font-sans);
+  font-family: var(--font-body);
 
   background-color: var(--color-background);
   color: var(--color-foreground);

--- a/src/foundations/setup/globals-prefers-schema.css
+++ b/src/foundations/setup/globals-prefers-schema.css
@@ -103,7 +103,7 @@
 }
 
 body {
-  font-family: var(--font-body);
+  font-family: var(--font-ui);
 
   background-color: var(--color-background);
   color: var(--color-foreground);

--- a/src/foundations/ui/toaster/page.mdx
+++ b/src/foundations/ui/toaster/page.mdx
@@ -9,6 +9,8 @@ files:
 dependencies:
   - name: useTopLayer
     href: /hooks/use-top-layer
+  - name: composeRefs
+    href: /utils/compose-refs
   - name: motion
     href: https://motion.dev
 

--- a/src/foundations/ui/toaster/toaster.tsx
+++ b/src/foundations/ui/toaster/toaster.tsx
@@ -5,8 +5,9 @@ import {
 } from '@phosphor-icons/react/dist/ssr';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import type { ComponentPropsWithoutRef } from 'react';
-import { useEffect, useSyncExternalStore } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import { useTopLayer } from '@/foundations/hooks/use-top-layer/use-top-layer';
+import { composeRefs } from '@/foundations/utils/compose-refs/compose-refs';
 import { cn } from '@/lib/utils/classnames';
 
 const DEFAULT_TOAST_DURATION_MS = 7000;
@@ -152,10 +153,11 @@ const toast = (toast: Omit<Toast, 'id'>) => {
 
 const Toaster = ({ className }: { className?: string }) => {
   const toasts = useToastStore();
-  const ref = useTopLayer<HTMLDivElement>(true);
+  const elementRef = useRef<HTMLDivElement>(null);
+  const topLayerRef = useTopLayer<HTMLDivElement>(true);
 
   useEffect(() => {
-    const element = ref.current;
+    const element = elementRef.current;
     if (!element) return;
 
     // Modals use the DOM top-layer (dialogs, drawers, etc.), where stacking order is
@@ -173,11 +175,11 @@ const Toaster = ({ className }: { className?: string }) => {
     return () => {
       window.removeEventListener('ui:modal-open', onModalOpen);
     };
-  }, [ref]);
+  }, []);
 
   return (
     <div
-      ref={ref}
+      ref={composeRefs(elementRef, topLayerRef)}
       data-toaster-provider
       className={cn(
         'fixed flex size-full flex-col items-end justify-end overflow-hidden bg-transparent px-4 py-3',

--- a/src/foundations/ui/tooltip/tooltip.tsx
+++ b/src/foundations/ui/tooltip/tooltip.tsx
@@ -36,7 +36,9 @@ import { Slot } from '@/foundations/components/slot/slot';
 import { useTopLayer } from '@/foundations/hooks/use-top-layer/use-top-layer';
 import { cn } from '@/lib/utils/classnames';
 
-// Let's keep an eye on popover="hint", it might be able to handle the tooltip logic natively
+// `popover="hint"` is the right type for tooltips: hints stack above any
+// `popover="manual"` already open (so a Tooltip inside a Popover floats above
+// the Popover), and don't dismiss other popovers when shown.
 // https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_hint_popover_state
 
 const DEFAULT_DELAY_IN = 600;
@@ -248,7 +250,7 @@ const TooltipContent = ({
 
   const { isMounted, status } = useTransitionStatus(context, { duration: 0 });
 
-  const topLayerRef = useTopLayer<HTMLDivElement>(isMounted);
+  const topLayerRef = useTopLayer<HTMLDivElement>(isMounted, 'hint');
   const ref = useMergeRefs([refs.setFloating, refProp, topLayerRef]);
 
   if (!isMounted) return null;

--- a/src/pages/[...path]/index.astro
+++ b/src/pages/[...path]/index.astro
@@ -60,7 +60,7 @@ const lastModified = await getPageLastModifiedTime(page);
 
     <section>
       <div class="mb-8">
-        <h1 class="text-3xl font-bold">{page.data.title}</h1>
+        <h1 class="font-heading text-3xl font-bold tracking-tight">{page.data.title}</h1>
         <p class="text-foreground-secondary mt-2 text-pretty">{page.data.description}</p>
       </div>
     </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,8 +17,9 @@
 }
 
 @theme {
-  --font-sans:
+  --font-body:
     "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-heading: var(--font-body);
   --font-mono: "Geist Mono", ui-monospace, monospace;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,7 @@
 @theme {
   --font-body:
     "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-ui: var(--font-body);
   --font-heading: var(--font-body);
   --font-mono: "Geist Mono", ui-monospace, monospace;
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -2,6 +2,8 @@
 
 @layer base {
   [data-markdown] :not(:where([data-escape-markdown], [data-escape-markdown] *)) {
+    @apply font-body;
+
     &:is(h1, h2, h3, h4, h5, h6) {
       @apply mt-[2em] mb-[1em] font-heading font-semibold tracking-tight [&_a]:no-underline;
     }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -3,7 +3,7 @@
 @layer base {
   [data-markdown] :not(:where([data-escape-markdown], [data-escape-markdown] *)) {
     &:is(h1, h2, h3, h4, h5, h6) {
-      @apply mt-[2em] mb-[1em] font-semibold tracking-tight [&_a]:no-underline;
+      @apply mt-[2em] mb-[1em] font-heading font-semibold tracking-tight [&_a]:no-underline;
     }
 
     &:is(h1) {


### PR DESCRIPTION
This PR makes typography a little bit more first-class citizen in this project. 
As a basis for design systems, it's important that we have good ergonomics for updating the look and feel for the entire project. This is what drove the decision of introducing border radius and inset CSS vars that control the "roundness" of the entire library.
Similarly, now we introduce a bit more thoughtful way of controlling the design system's typography system (while keeping the surface area as minimal as possible).

We introduce a few typography tokens in a way it doesn't requires us to change all components to opt-in:
```css
:root {
  --font-body: ui-sans-serif, system-ui, sans-serif;
  --font-ui: var(--font-body);
  --font-heading: var(--font-body);
  --font-mono: ui-monospace, monospace;
}
```

```css
body {
  font-family: var(--font-ui);
}
```

The mechanism is:
- font-ui inherits font-body by default.
- font-body should be added in more strategic places where prose and paragraphs are more likely.
- if we set a different font-body and font-ui values, the font-ui will be more prevalent because it's more likely that it's a "standard" font.

This way we don't have to retro-fit all of our library to use `font-ui`. 

it actually makes sense:
**we want UI chrome to be the *default inheritance* (so every Button/Badge/Input etc. just works without opt-in classes). That means the body element MUST resolve to "chrome font", because everything inherits from body.**

Another thing I considered was to name the css var `--font-prose` instead of `--font-body`, but I'll believe that people think of "body" as in "heading text / body text" and not the DOM element.