### PR TITLE
Fix menu component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,21 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "always"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[astro]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -31,7 +31,7 @@ export const Menu = ({ items, currentPath: initialPath }: MenuProps) => {
         <Disclosure key={item.title} defaultOpen className="mb-4">
           <Disclosure.Trigger
             className={cn(
-              'sticky top-0 mx-(--inset) flex w-[calc(100%-calc(var(--inset)*2))] cursor-pointer items-center justify-between bg-background px-3 py-2 font-medium text-foreground-secondary text-sm capitalize',
+              'sticky top-0 z-10 mx-(--inset) flex w-[calc(100%-calc(var(--inset)*2))] cursor-pointer items-center justify-between bg-background px-3 py-2 font-medium text-foreground-secondary text-sm capitalize',
               'before:absolute before:bottom-full before:left-0 before:h-4 before:w-full before:bg-background'
             )}
           >


### PR DESCRIPTION
## What changed

- Fixed the menu layering behavior by ensuring sticky section headers use the intended stacking order in `src/components/menu.tsx` (`Disclosure.Trigger` with `z-10`).
- Updated workspace formatter settings in `.vscode/settings.json` to enforce project-consistent save behavior:
  - Biome for `javascript`, `javascriptreact`, `typescript`, and `typescriptreact`
  - Prettier for `astro`
  - Biome fixes on save via `source.fixAll.biome: "always"`

## Fix

- Resolves menu z-index/stacking issues during scroll so sticky menu headers render in the correct visual layer.
- Prevents formatting drift while touching menu code by ensuring TS/TSX files are formatted by Biome instead of accidentally falling back to Prettier.

### Before
<img width="491" height="360" alt="screenshot-menu-1" src="https://github.com/user-attachments/assets/06f9e9c7-186f-4e39-b7b0-08e9879bc8b6" />

### After
<img width="516" height="926" alt="screenshot-menu-2" src="https://github.com/user-attachments/assets/e2b9b149-705f-47a3-8d84-a86a317fe0ac" />


## Why `.vscode/settings.json` changed

- The project intentionally uses Biome for JS/TS and Prettier for Astro, but formatter precedence can still be affected by user-level language-specific defaults.
- Adding explicit per-language formatter settings at workspace level ensures this repo’s styling rules are applied consistently for all contributors.
- Enabling Biome fix-on-save also applies lint-driven fixes (including class sorting where configured) as part of normal save flow.