### PR TITLE
Resizable

### DIFF
--- a/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
@@ -10,14 +10,8 @@ export default function ResizableCollapsiblePreview() {
   return (
     <Resizable className="h-72 w-200 max-w-2xl rounded-xl border border-border">
       <Resizable.Panel
-        onResize={(size, setSize) => {
-          if (size < 100) {
-            setSize(48);
-            setCollapsed(true);
-          } else {
-            setCollapsed(false);
-          }
-        }}
+        snap={(size) => (size < 100 ? 48 : size)}
+        onResize={(size) => setCollapsed(size < 100)}
       >
         <div className="grid h-full place-items-center p-4">
           <span className="text-foreground-secondary text-sm">

--- a/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
@@ -1,4 +1,4 @@
-import { SidebarIcon } from "@phosphor-icons/react";
+import { SidebarIcon } from "@phosphor-icons/react/dist/ssr";
 import { useState } from "react";
 import { Resizable } from "@/foundations/ui/resizable/resizable";
 
@@ -25,6 +25,7 @@ export default function ResizableCollapsiblePreview() {
           </span>
         </div>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel>
         <div className="grid h-full grow place-items-center p-4">
           <span className="text-foreground-secondary text-sm">Editor</span>

--- a/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-collapsible.preview.tsx
@@ -1,0 +1,35 @@
+import { SidebarIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizableCollapsiblePreview() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <Resizable className="h-72 w-200 max-w-2xl rounded-xl border border-border">
+      <Resizable.Panel
+        onResize={(size, setSize) => {
+          if (size < 100) {
+            setSize(48);
+            setCollapsed(true);
+          } else {
+            setCollapsed(false);
+          }
+        }}
+      >
+        <div className="grid h-full place-items-center p-4">
+          <span className="text-foreground-secondary text-sm">
+            {collapsed ? <SidebarIcon /> : "Sidebar"}
+          </span>
+        </div>
+      </Resizable.Panel>
+      <Resizable.Panel>
+        <div className="grid h-full grow place-items-center p-4">
+          <span className="text-foreground-secondary text-sm">Editor</span>
+        </div>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-min-max.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-min-max.preview.tsx
@@ -1,0 +1,16 @@
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizableMinMaxPreview() {
+  return (
+    <Resizable className="h-72 w-200 max-w-2xl rounded-xl border border-border">
+      <Resizable.Panel className="grid min-w-32 max-w-64 place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Sidebar</span>
+      </Resizable.Panel>
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Content</span>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-min-max.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-min-max.preview.tsx
@@ -8,6 +8,7 @@ export default function ResizableMinMaxPreview() {
       <Resizable.Panel className="grid min-w-32 max-w-64 place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Content</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
@@ -8,11 +8,13 @@ export default function ResizableNestedPreview() {
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel>
         <Resizable orientation="vertical" className="h-full">
           <Resizable.Panel className="grid place-items-center p-4">
             <span className="text-foreground-secondary text-sm">Main</span>
           </Resizable.Panel>
+          <Resizable.Handle />
           <Resizable.Panel className="grid place-items-center p-4">
             <span className="text-foreground-secondary text-sm">Console</span>
           </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
@@ -1,10 +1,10 @@
 import { Resizable } from "@/foundations/ui/resizable/resizable";
 
-export const meta = { layout: "centered" } as const;
+export const meta = { layout: "fullscreen", mode: "iframe" } as const;
 
 export default function ResizableNestedPreview() {
   return (
-    <Resizable className="h-96 w-full max-w-2xl rounded-xl border border-border">
+    <Resizable className="h-screen w-screen">
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-nested.preview.tsx
@@ -1,0 +1,23 @@
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizableNestedPreview() {
+  return (
+    <Resizable className="h-96 w-full max-w-2xl rounded-xl border border-border">
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Sidebar</span>
+      </Resizable.Panel>
+      <Resizable.Panel>
+        <Resizable orientation="vertical" className="h-full">
+          <Resizable.Panel className="grid place-items-center p-4">
+            <span className="text-foreground-secondary text-sm">Main</span>
+          </Resizable.Panel>
+          <Resizable.Panel className="grid place-items-center p-4">
+            <span className="text-foreground-secondary text-sm">Console</span>
+          </Resizable.Panel>
+        </Resizable>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-persist.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-persist.preview.tsx
@@ -1,0 +1,19 @@
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizablePersistPreview() {
+  return (
+    <Resizable
+      persist="resizable-persist-preview"
+      className="h-72 w-200 max-w-2xl rounded-xl border border-border"
+    >
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Sidebar</span>
+      </Resizable.Panel>
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Editor</span>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-persist.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-persist.preview.tsx
@@ -11,6 +11,7 @@ export default function ResizablePersistPreview() {
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Editor</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable-set-size.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-set-size.preview.tsx
@@ -1,0 +1,38 @@
+import { useRef } from "react";
+import { Resizable, type ResizablePanelHandle } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizableSetSizePreview() {
+  const sidebar = useRef<ResizablePanelHandle>(null);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => sidebar.current?.resize(120)}
+          className="rounded-md border border-border px-2 py-1 text-foreground-secondary text-sm hover:border-foreground/24"
+        >
+          Narrow
+        </button>
+        <button
+          type="button"
+          onClick={() => sidebar.current?.resize(400)}
+          className="rounded-md border border-border px-2 py-1 text-foreground-secondary text-sm hover:border-foreground/24"
+        >
+          Wide
+        </button>
+      </div>
+      <Resizable className="h-72 w-200 max-w-2xl rounded-xl border border-border">
+        <Resizable.Panel ref={sidebar} className="grid place-items-center p-4">
+          <span className="text-foreground-secondary text-sm">Sidebar</span>
+        </Resizable.Panel>
+        <Resizable.Handle />
+        <Resizable.Panel className="grid place-items-center p-4">
+          <span className="text-foreground-secondary text-sm">Editor</span>
+        </Resizable.Panel>
+      </Resizable>
+    </div>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
@@ -1,13 +1,10 @@
 import { Resizable } from "@/foundations/ui/resizable/resizable";
 
-export const meta = { layout: "centered" } as const;
+export const meta = { layout: "fullscreen", mode: "iframe" } as const;
 
 export default function ResizableVerticalPreview() {
   return (
-    <Resizable
-      orientation="vertical"
-      className="h-96 w-full max-w-md rounded-xl border border-border"
-    >
+    <Resizable orientation="vertical" className="h-screen w-screen">
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Top</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
@@ -6,10 +6,10 @@ export default function ResizableVerticalPreview() {
   return (
     <Resizable orientation="vertical" className="h-screen w-screen">
       <Resizable.Panel className="grid place-items-center p-4">
-        <span className="text-foreground-secondary text-sm">Top</span>
+        <span className="text-foreground-secondary text-sm">Editor</span>
       </Resizable.Panel>
       <Resizable.Panel className="grid place-items-center p-4">
-        <span className="text-foreground-secondary text-sm">Bottom</span>
+        <span className="text-foreground-secondary text-sm">Terminal</span>
       </Resizable.Panel>
     </Resizable>
   );

--- a/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
@@ -1,0 +1,19 @@
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizableVerticalPreview() {
+  return (
+    <Resizable
+      orientation="vertical"
+      className="h-96 w-full max-w-md rounded-xl border border-border"
+    >
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Top</span>
+      </Resizable.Panel>
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Bottom</span>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable-vertical.preview.tsx
@@ -8,6 +8,7 @@ export default function ResizableVerticalPreview() {
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Editor</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Terminal</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable.preview.tsx
@@ -9,10 +9,10 @@ export default function ResizablePreview() {
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>
       <Resizable.Panel className="grid w-24 min-w-24 place-items-center p-4">
-        <span className="text-foreground-secondary text-sm">Content</span>
+        <span className="text-foreground-secondary text-sm">Editor</span>
       </Resizable.Panel>
       <Resizable.Panel className="grid place-items-center p-4">
-        <span className="text-foreground-secondary text-sm">Third</span>
+        <span className="text-foreground-secondary text-sm">Preview</span>
       </Resizable.Panel>
     </Resizable>
   );

--- a/src/foundations/ui/resizable/examples/resizable.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable.preview.tsx
@@ -8,9 +8,11 @@ export default function ResizablePreview() {
       <Resizable.Panel className="grid w-full place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Sidebar</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel className="grid w-24 min-w-24 place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Editor</span>
       </Resizable.Panel>
+      <Resizable.Handle />
       <Resizable.Panel className="grid place-items-center p-4">
         <span className="text-foreground-secondary text-sm">Preview</span>
       </Resizable.Panel>

--- a/src/foundations/ui/resizable/examples/resizable.preview.tsx
+++ b/src/foundations/ui/resizable/examples/resizable.preview.tsx
@@ -1,0 +1,19 @@
+import { Resizable } from "@/foundations/ui/resizable/resizable";
+
+export const meta = { layout: "centered" } as const;
+
+export default function ResizablePreview() {
+  return (
+    <Resizable className="h-72 w-200 max-w-2xl rounded-xl border border-border">
+      <Resizable.Panel className="grid w-full place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Sidebar</span>
+      </Resizable.Panel>
+      <Resizable.Panel className="grid w-24 min-w-24 place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Content</span>
+      </Resizable.Panel>
+      <Resizable.Panel className="grid place-items-center p-4">
+        <span className="text-foreground-secondary text-sm">Third</span>
+      </Resizable.Panel>
+    </Resizable>
+  );
+}

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -31,10 +31,9 @@ folder: UI
 </Resizable>
 ```
 
-Panels must be **direct children** of `Resizable` — the container splits its space
-equally between them and assigns each its index. Every panel except the first renders
-a drag handle on its leading edge, so a boundary appears between each adjacent pair
-with no extra markup.
+Panels must be **direct children** of `Resizable` — the container splits its space between them
+and assigns each its index. Every panel except the first renders a drag handle on its leading edge,
+so a boundary appears between each adjacent pair with no extra markup.
 
 ## API Reference
 
@@ -56,7 +55,7 @@ Extends the `div` element.
 
 Extends the `div` element.
 
-Panels split the container equally. Their sizes are tracked as percentages that a
+Panels split the container’s space. Their sizes are tracked as percentages that a
 drag redistributes between adjacent panels.
 
 <PropsTable

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -1,0 +1,120 @@
+---
+title: Resizable
+description: >-
+  A container whose panels can be resized by dragging the handle on the boundary between them
+preview: resizable
+files:
+  - src/foundations/ui/resizable/resizable.tsx
+dependencies:
+  - name: Slot
+    href: /components/slot
+  - name: composeRefs
+    href: /utils/compose-refs
+  - name: math/clamp
+    href: /utils/math/#clamp
+
+folder: UI
+---
+
+## Features
+
+- **Inferred Handles**: Just list panels — a drag handle is placed on the boundary between each pair automatically
+- **Percentage-based**: Sizes are percentages of the container, so layouts stay responsive
+- **Even by default**: Panels split the container equally; drag a boundary to redistribute
+- **Keyboard Support**: Handles are focusable and resizable with the arrow keys (plus `Home` / `End`)
+- **Horizontal & Vertical**: Lay panels out in a row or a column
+- **Nestable**: A panel can hold another `Resizable` for grid-like layouts
+
+## Anatomy
+
+```tsx
+<Resizable orientation="horizontal">
+  <Resizable.Panel />
+  <Resizable.Panel />
+</Resizable>
+```
+
+Panels must be **direct children** of `Resizable` — the container splits its space
+equally between them and assigns each its index. Every panel except the first renders
+a drag handle on its leading edge, so a boundary appears between each adjacent pair
+with no extra markup.
+
+## API Reference
+
+### Resizable
+
+Extends the `div` element.
+
+<PropsTable
+  definition={{
+    orientation: {
+      type: '"horizontal" | "vertical"',
+      default: '"horizontal"',
+      description: "Axis along which panels are laid out and resized.",
+    },
+    keyboardStep: {
+      type: "number",
+      default: "10",
+      description: "Percentage points a handle moves per arrow-key press.",
+    },
+    onResize: {
+      type: "(sizes: number[]) => void",
+      description: "Called with the new list of panel sizes (percentages) whenever they change.",
+    },
+  }}
+/>
+
+### Resizable.Panel
+
+Extends the `div` element.
+
+Panels split the container equally. Their sizes are tracked as percentages that a
+drag redistributes between adjacent panels.
+
+<PropsTable
+  definition={{
+    asChild: {
+      type: "boolean",
+      description: "Whether to merge props onto the child element.",
+    },
+  }}
+/>
+
+### Handle
+
+The drag handle is inferred — you don't render it. Each panel except the first
+renders one on its leading edge. It is a `role="separator"` element that is focusable
+and resizable with the keyboard, and exposes `data-dragging` while a drag is in
+progress. To restyle it, edit the handle markup in your copy of `resizable.tsx`.
+
+## Examples
+
+### Horizontal
+
+The default: panels sit in a row, dragging the handle left and right.
+
+<Preview slug="resizable" />
+
+### Vertical
+
+Set `orientation="vertical"` to stack panels and drag the handle up and down.
+
+<Preview slug="resizable-vertical" />
+
+### Nested
+
+Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
+
+<Preview slug="resizable-nested" />
+
+## Accessibility
+
+- Each handle is a `role="separator"` element with `tabIndex={0}`, so it is reachable by keyboard.
+- `aria-orientation` reflects the separator itself — a horizontal layout is split by a vertical separator, and vice versa.
+- `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` describe the leading panel's size within the pair it can span.
+- Arrow keys move the focused handle by `keyboardStep`; `Home` and `End` jump it to its minimum and maximum.
+
+## Best Practices
+
+1. **Set a size on the container**: The container has no intrinsic size — give it a height (and width, if needed) so panels have space to fill.
+2. **Keep panel content resilient**: Panels can currently be dragged down to zero width, so make sure content degrades gracefully when a panel gets narrow.

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -20,8 +20,9 @@ folder: UI
 
 - **Inferred Handles**: Just list panels — a drag handle is placed on the boundary between each pair automatically
 - **Percentage-based**: Sizes are percentages of the container, so layouts stay responsive
+- **Inferred Bounds**: Minimum and maximum sizes are inferred from the panel's css `min-width` / `min-height` and `max-width` / `max-height`
 - **Even by default**: Panels split the container equally; drag a boundary to redistribute
-- **Keyboard Support**: Handles are focusable and resizable with the arrow keys (plus `Home` / `End`)
+- **Keyboard Support**: Handles are focusable and resizable with the arrow keys
 - **Horizontal & Vertical**: Lay panels out in a row or a column
 - **Nestable**: A panel can hold another `Resizable` for grid-like layouts
 

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -75,10 +75,15 @@ space is distributed to the other panels by flexbox before the lock-in happens.
       type: "boolean",
       description: "Whether to merge props onto the child element.",
     },
-    onResize: {
-      type: "(size: number, setSize: (size: number) => void) => void",
+    snap: {
+      type: "(size: number) => number",
       description:
-        "Called during drag and keyboard resize with the panel's current size in pixels. Use setSize to override the size imperatively — useful for snapping or collapsing behaviour.",
+        "Transform the panel's size during a resize: receives the pointer-tracked size in pixels and returns the size the panel should take. Runs every frame — return a fixed size to snap or collapse, or the size unchanged for a no-op.",
+    },
+    onResize: {
+      type: "(size: number) => void",
+      description:
+        "Read-only notification called during drag and keyboard resize with the panel's pointer-tracked size in pixels.",
     },
   }}
 />
@@ -126,7 +131,7 @@ Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
 
 ### Collapsible panel
 
-Use `onResize` to snap a panel to a collapsed size when it crosses a threshold. The callback fires during drag with the current size in pixels; call `setSize` to override it.
+Use `snap` to pin a panel to a collapsed size when it crosses a threshold — it returns the size the panel should take. Pair it with `onResize` to react to the change (here, swapping the label for an icon).
 
 <Preview slug="resizable-collapsible" />
 

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -88,6 +88,14 @@ space is distributed to the other panels by flexbox before the lock-in happens.
   }}
 />
 
+A panel's `ref` exposes an imperative `ResizablePanelHandle` (not the DOM node) so you can
+set its size programmatically — a "reset" button, presets, or a button-driven collapse:
+
+```tsx
+const sidebar = useRef<ResizablePanelHandle>(null);
+// sidebar.current?.resize(300) — set the panel to 300px; the adjacent panel absorbs the difference
+```
+
 ### Resizable.Handle
 
 Extends the `div` element.
@@ -134,6 +142,12 @@ Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
 Use `snap` to pin a panel to a collapsed size when it crosses a threshold — it returns the size the panel should take. Pair it with `onResize` to react to the change (here, swapping the label for an icon).
 
 <Preview slug="resizable-collapsible" />
+
+### Set size externally
+
+Grab a panel's `ref` to get a `ResizablePanelHandle` and call `resize(size)` to set its size in pixels from outside a drag — for presets, a reset button, or programmatic collapse.
+
+<Preview slug="resizable-set-size" />
 
 ## Accessibility
 

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -18,6 +18,7 @@ folder: UI
 
 ## Features
 
+- **CSS-driven initial sizing**: Each panel's starting size is its computed CSS width (or height) at mount — set it with a `width` utility or any flex sizing class, no prop needed
 - **Inferred bounds**: Minimum and maximum sizes are derived from the panel's CSS `min-width` / `min-height` and `max-width` / `max-height` — no props required
 - **Percentage-based sizing**: Panels are sized as percentages of the container so the layout adapts as the container changes
 - **Keyboard support**: Handles are focusable and accept arrow key input to nudge the boundary
@@ -55,8 +56,11 @@ Extends the `div` element.
 
 Extends the `div` element.
 
-Panels split the container’s space. Their sizes are tracked as percentages that a
-drag redistributes between adjacent panels.
+Panels split the container’s space. On mount, each panel’s computed CSS size is read
+and locked in as a percentage of the container — that percentage then changes as the
+user drags. This means initial sizing is entirely CSS-driven: use a `width` class
+(e.g. `w-64`, `w-1/3`) to set the starting size of a panel, and the rest of the
+space is distributed to the other panels by flexbox before the lock-in happens.
 
 <PropsTable
   definition={{

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -83,6 +83,12 @@ The default: panels sit in a row, dragging the handle left and right.
 
 <Preview slug="resizable" />
 
+### Min / max size
+
+Apply `min-width` / `max-width` (or `min-height` / `max-height` for vertical) directly on a panel. The handle stops automatically at those boundaries.
+
+<Preview slug="resizable-min-max" />
+
 ### Vertical
 
 Set `orientation="vertical"` to stack panels and drag the handle up and down.

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -10,8 +10,8 @@ dependencies:
     href: /components/slot
   - name: composeRefs
     href: /utils/compose-refs
-  - name: InstanceCounter
-    href: /components/instance-counter
+  - name: math/clamp
+    href: /utils/math/#clamp
 
 folder: UI
 ---

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -21,6 +21,7 @@ folder: UI
 - **CSS-driven initial sizing**: Each panel's starting size is its computed CSS width (or height) at mount — set it with a `width` utility or any flex sizing class, no prop needed
 - **Inferred bounds**: Minimum and maximum sizes are derived from the panel's CSS `min-width` / `min-height` and `max-width` / `max-height` — no props required
 - **Percentage-based sizing**: Panels are sized as percentages of the container so the layout adapts as the container changes
+- **Persistent sizes**: Pass a `persist` key to save and restore panel sizes across visits via `localStorage`
 - **Keyboard support**: Handles are focusable and accept arrow key input to nudge the boundary
 
 ## Anatomy
@@ -48,6 +49,11 @@ Extends the `div` element.
       type: '"horizontal" | "vertical"',
       default: '"horizontal"',
       description: "Axis along which panels are laid out and resized.",
+    },
+    persist: {
+      type: "string",
+      description:
+        "Unique key used to save panel sizes to localStorage and restore them on the next visit. Must be unique per layout — if the panel count changes, stored sizes for unrecognised panels are ignored and those panels fall back to their CSS size.",
     },
   }}
 />
@@ -91,6 +97,12 @@ The default: panels sit in a row, dragging the handle left and right.
 Apply `min-width` / `max-width` (or `min-height` / `max-height` for vertical) directly on a panel. The handle stops automatically at those boundaries.
 
 <Preview slug="resizable-min-max" />
+
+### Persistent sizes
+
+Pass a unique `persist` key to save panel sizes to `localStorage`. Sizes are restored on the next visit — drag the handle and reload the page to see it in action.
+
+<Preview slug="resizable-persist" />
 
 ### Vertical
 

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -10,21 +10,17 @@ dependencies:
     href: /components/slot
   - name: composeRefs
     href: /utils/compose-refs
-  - name: math/clamp
-    href: /utils/math/#clamp
+  - name: InstanceCounter
+    href: /components/instance-counter
 
 folder: UI
 ---
 
 ## Features
 
-- **Inferred Handles**: Just list panels — a drag handle is placed on the boundary between each pair automatically
-- **Percentage-based**: Sizes are percentages of the container, so layouts stay responsive
-- **Inferred Bounds**: Minimum and maximum sizes are inferred from the panel's css `min-width` / `min-height` and `max-width` / `max-height`
-- **Even by default**: Panels split the container equally; drag a boundary to redistribute
-- **Keyboard Support**: Handles are focusable and resizable with the arrow keys
-- **Horizontal & Vertical**: Lay panels out in a row or a column
-- **Nestable**: A panel can hold another `Resizable` for grid-like layouts
+- **Inferred bounds**: Minimum and maximum sizes are derived from the panel's CSS `min-width` / `min-height` and `max-width` / `max-height` — no props required
+- **Percentage-based sizing**: Panels are sized as percentages of the container so the layout adapts as the container changes
+- **Keyboard support**: Handles are focusable and accept arrow key input to nudge the boundary
 
 ## Anatomy
 
@@ -53,15 +49,6 @@ Extends the `div` element.
       default: '"horizontal"',
       description: "Axis along which panels are laid out and resized.",
     },
-    keyboardStep: {
-      type: "number",
-      default: "10",
-      description: "Percentage points a handle moves per arrow-key press.",
-    },
-    onResize: {
-      type: "(sizes: number[]) => void",
-      description: "Called with the new list of panel sizes (percentages) whenever they change.",
-    },
   }}
 />
 
@@ -85,8 +72,8 @@ drag redistributes between adjacent panels.
 
 The drag handle is inferred — you don't render it. Each panel except the first
 renders one on its leading edge. It is a `role="separator"` element that is focusable
-and resizable with the keyboard, and exposes `data-dragging` while a drag is in
-progress. To restyle it, edit the handle markup in your copy of `resizable.tsx`.
+and resizable with the keyboard. To restyle it, edit the handle markup in your copy
+of `resizable.tsx`.
 
 ## Examples
 
@@ -111,11 +98,10 @@ Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
 ## Accessibility
 
 - Each handle is a `role="separator"` element with `tabIndex={0}`, so it is reachable by keyboard.
-- `aria-orientation` reflects the separator itself — a horizontal layout is split by a vertical separator, and vice versa.
-- `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` describe the leading panel's size within the pair it can span.
-- Arrow keys move the focused handle by `keyboardStep`; `Home` and `End` jump it to its minimum and maximum.
+- `aria-orientation` reflects the axis of the separator — a horizontal layout uses a vertical separator, and vice versa.
+- Arrow keys move the focused handle by 10px; the handle stops at the bounds derived from the adjacent panels' CSS constraints.
 
 ## Best Practices
 
 1. **Set a size on the container**: The container has no intrinsic size — give it a height (and width, if needed) so panels have space to fill.
-2. **Keep panel content resilient**: Panels can currently be dragged down to zero width, so make sure content degrades gracefully when a panel gets narrow.
+2. **Use CSS to constrain panels**: Set `min-width` / `min-height` on a panel to prevent it from being collapsed, and `max-width` / `max-height` to cap how large it can grow. The handle stops automatically at these boundaries.

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -29,13 +29,14 @@ folder: UI
 ```tsx
 <Resizable orientation="horizontal">
   <Resizable.Panel />
+  <Resizable.Handle />
   <Resizable.Panel />
 </Resizable>
 ```
 
-Panels must be **direct children** of `Resizable` — the container splits its space between them
-and assigns each its index. Every panel except the first renders a drag handle on its leading edge,
-so a boundary appears between each adjacent pair with no extra markup.
+Panels and handles must be **direct children** of `Resizable`. Place a `Resizable.Handle` between
+any two panels you want to be resizable — omit it to create a fixed boundary. Panels without a
+handle between them cannot be resized against each other.
 
 ## API Reference
 
@@ -74,15 +75,22 @@ space is distributed to the other panels by flexbox before the lock-in happens.
       type: "boolean",
       description: "Whether to merge props onto the child element.",
     },
+    onResize: {
+      type: "(size: number, setSize: (size: number) => void) => void",
+      description:
+        "Called during drag and keyboard resize with the panel's current size in pixels. Use setSize to override the size imperatively — useful for snapping or collapsing behaviour.",
+    },
   }}
 />
 
-### Handle
+### Resizable.Handle
 
-The drag handle is inferred — you don't render it. Each panel except the first
-renders one on its leading edge. It is a `role="separator"` element that is focusable
-and resizable with the keyboard. To restyle it, edit the handle markup in your copy
-of `resizable.tsx`.
+Extends the `div` element.
+
+A draggable separator placed explicitly between panels. It finds its adjacent panels by DOM
+traversal, so it works correctly regardless of where it appears between two
+`Resizable.Panel` elements. It is a `role="separator"` element, focusable by keyboard, and
+accepts `className` and `ref` for customisation.
 
 ## Examples
 
@@ -118,7 +126,7 @@ Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
 
 ### Collapsible panel
 
-Panel sizes are plain inline styles, so you can collapse a panel programmatically by holding a ref to it and setting its `width` (or `height`) directly. Set both adjacent panels to keep the layout consistent.
+Use `onResize` to snap a panel to a collapsed size when it crosses a threshold. The callback fires during drag with the current size in pixels; call `setSize` to override it.
 
 <Preview slug="resizable-collapsible" />
 

--- a/src/foundations/ui/resizable/page.mdx
+++ b/src/foundations/ui/resizable/page.mdx
@@ -116,6 +116,12 @@ Put a `Resizable` inside a `Resizable.Panel` to build grid-like layouts.
 
 <Preview slug="resizable-nested" />
 
+### Collapsible panel
+
+Panel sizes are plain inline styles, so you can collapse a panel programmatically by holding a ref to it and setting its `width` (or `height`) directly. Set both adjacent panels to keep the layout consistent.
+
+<Preview slug="resizable-collapsible" />
+
 ## Accessibility
 
 - Each handle is a `role="separator"` element with `tabIndex={0}`, so it is reachable by keyboard.

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -6,44 +6,48 @@ import {
   use,
   useCallback,
   useEffect,
+  useId,
   useImperativeHandle,
-  useMemo,
   useRef,
 } from "react";
-import {
-  InstanceCounterProvider,
-  useInstanceCounter,
-} from "@/foundations/components/instance-counter/instance-counter";
 import { Slot } from "@/foundations/components/slot/slot";
 import { composeRefs } from "@/foundations/utils/compose-refs/compose-refs";
+import { clamp } from "@/foundations/utils/math/clamp";
 import { cn } from "@/lib/utils/classnames";
 
 // The number of pixels to move when using the keyboard to resize.
 const KEYBOARD_ARROW_PX_STEP = 10;
 
-const getLocalstorageKey = (id: string) => `foundations-ui:resizable-${id}`;
+const findAdjacentPanel = (from: Element, direction: "next" | "previous") => {
+  let element = (
+    direction === "next" ? from.nextElementSibling : from.previousElementSibling
+  ) as HTMLElement | null;
+  while (element && !element.hasAttribute("data-ui-resizable-panel")) {
+    element = (
+      direction === "next" ? element.nextElementSibling : element.previousElementSibling
+    ) as HTMLElement | null;
+  }
+  return element;
+};
 
 type Orientation = "horizontal" | "vertical";
 
-type ResizeHandler = {
-  apply: (pxDelta: number) => void;
+type RegisteredPanel = {
+  id: string;
+  onResize?: (size: number) => void;
+  snap?: (size: number) => number;
 };
 
-type PanelCallbacks = {
-  // Transform the panel's size during a resize — return the size (px) it should
-  // take. Runs every frame, so it can pin/snap (e.g. collapse) the panel.
-  snap?: (size: number) => number;
-  // Read-only notification with the pointer-tracked size (px) during a resize.
-  onResize?: (size: number) => void;
+type ResizeHandler = {
+  move: (delta: number) => void;
+  set: (size: number) => void;
+  commit: () => void;
 };
 
 type ResizableContextValue = {
   orientation: Orientation;
-  scope: React.RefObject<HTMLDivElement | null>;
-  registerPanelCallbacks: (index: number, callbacks: PanelCallbacks) => () => void;
-  resizePanel: (index: number, size: number) => void;
-  createResizeHandler: (panelBefore: HTMLElement, panelAfter: HTMLElement) => ResizeHandler;
-  persist: () => void;
+  registerPanel: (element: HTMLElement, panel: RegisteredPanel) => () => void;
+  createResizeHandler: (beforePanel: HTMLElement, afterPanel: HTMLElement) => ResizeHandler;
 };
 
 const ResizableContext = createContext<ResizableContextValue | null>(null);
@@ -56,74 +60,79 @@ const useResizableContext = () => {
 
 type ResizableProps = Omit<React.ComponentPropsWithRef<"div">, "onResize"> & {
   orientation?: Orientation;
-  persist?: string;
+  persist: string;
   children: React.ReactNode;
 };
 
 const Resizable = ({
   orientation = "horizontal",
-  persist: persistKey,
+  persist: persistId,
   className,
   children,
   ref,
   ...props
 }: ResizableProps) => {
   const scope = useRef<HTMLDivElement>(null);
-  const panelCallbacks = useRef<(PanelCallbacks | null)[]>([]);
+  const panels = useRef<Map<HTMLElement, RegisteredPanel>>(new Map());
 
-  const registerPanelCallbacks = useCallback((index: number, callbacks: PanelCallbacks) => {
-    panelCallbacks.current[index] = callbacks;
-    return () => {
-      panelCallbacks.current[index] = null;
-    };
+  const persistKey = persistId ? `foundations-resizable:${persistId}` : null;
+
+  const registerPanel = useCallback((element: HTMLElement, panel: RegisteredPanel) => {
+    panels.current.set(element, panel);
+    return () => panels.current.delete(element);
   }, []);
 
-  const keys = useMemo(() => {
-    return {
-      side: orientation === "horizontal" ? "width" : "height",
-      sideOffset: orientation === "horizontal" ? "offsetWidth" : "offsetHeight",
-      clientOffset: orientation === "horizontal" ? "clientX" : "clientY",
-    } as const;
-  }, [orientation]);
+  // Persist panel sizes to localStorage
+  const persist = useCallback(() => {
+    const root = scope.current;
+    if (!persistKey || !root) return;
+
+    const side = orientation === "horizontal" ? "width" : "height";
+
+    const sizes: Record<string, string> = {};
+    for (const [element, { id }] of panels.current.entries()) {
+      sizes[id] = element.style[side];
+    }
+
+    try {
+      localStorage.setItem(persistKey, JSON.stringify(sizes));
+    } catch {} // ignore localStorage errors
+  }, [persistKey, orientation]);
 
   const createResizeHandler = useCallback(
     (panelBefore: HTMLElement, panelAfter: HTMLElement) => {
       const root = scope.current;
-      if (!root) return { apply: () => undefined };
+      if (!root || !panelBefore || !panelAfter) {
+        return {
+          move: () => undefined,
+          set: () => undefined,
+          commit: () => undefined,
+        };
+      }
 
-      const panelBeforeIndex = parseInt(
-        panelBefore.getAttribute("data-ui-resizable-panel") ?? "",
-        10,
-      );
-      const panelAfterIndex = parseInt(
-        panelAfter.getAttribute("data-ui-resizable-panel") ?? "",
-        10,
-      );
-      // read a panel's registered callbacks fresh each frame (the panel may
-      // re-register mid-drag when its snap/onResize identity changes)
-      const readCallbacks = (index: number) =>
-        Number.isNaN(index) ? null : (panelCallbacks.current[index] ?? null);
+      const side = orientation === "horizontal" ? "width" : "height";
 
-      // sizes when drag started
-      const rootCurrent = root[keys.sideOffset];
-      const panelBeforeCurrent = panelBefore.getBoundingClientRect()[keys.side];
-      const panelAfterCurrent = panelAfter.getBoundingClientRect()[keys.side];
+      // sizes when resize started
+      const rootCurrent = root.getBoundingClientRect()[side];
+      const panelBeforeCurrent = panelBefore.getBoundingClientRect()[side];
+      const panelAfterCurrent = panelAfter.getBoundingClientRect()[side];
 
+      // calculate the min/max range for each panel based on its CSS properties
       const calcPanelRange = (panel: HTMLElement, oppositePanel: HTMLElement) => {
         const previousStyles = {
-          panel: panel.style[keys.side],
-          oppositePanel: oppositePanel.style[keys.side],
+          panel: panel.style[side],
+          oppositePanel: oppositePanel.style[side],
         };
 
-        panel.style[keys.side] = "0rem";
-        oppositePanel.style[keys.side] = "999rem";
-        const min = panel.getBoundingClientRect()[keys.side];
-        panel.style[keys.side] = "999rem";
-        oppositePanel.style[keys.side] = "0rem";
-        const max = panel.getBoundingClientRect()[keys.side];
+        panel.style[side] = "0rem";
+        oppositePanel.style[side] = "999rem";
+        const min = panel.getBoundingClientRect()[side];
+        panel.style[side] = "999rem";
+        oppositePanel.style[side] = "0rem";
+        const max = panel.getBoundingClientRect()[side];
 
-        panel.style[keys.side] = previousStyles.panel;
-        oppositePanel.style[keys.side] = previousStyles.oppositePanel;
+        panel.style[side] = previousStyles.panel;
+        oppositePanel.style[side] = previousStyles.oppositePanel;
 
         return { min, max };
       };
@@ -131,6 +140,12 @@ const Resizable = ({
       // size range for each panel
       const panelBeforeRange = calcPanelRange(panelBefore, panelAfter);
       const panelAfterRange = calcPanelRange(panelAfter, panelBefore);
+
+      // methods
+      const panelBeforeSnap = panels.current.get(panelBefore)?.snap;
+      const panelAfterSnap = panels.current.get(panelAfter)?.snap;
+      const panelBeforeOnResize = panels.current.get(panelBefore)?.onResize;
+      const panelAfterOnResize = panels.current.get(panelAfter)?.onResize;
 
       // store how much we've moved so far (in px)
       // so we can easily calculate the new size from the current size
@@ -140,7 +155,13 @@ const Resizable = ({
       // the space the two panels share stays constant during a drag
       const combined = panelBeforeCurrent + panelAfterCurrent;
 
-      const apply = (pxDelta: number) => {
+      // write the pair as percentages of the root; they always sum to `combined`
+      const write = (sizeBefore: number) => {
+        panelBefore.style[side] = `${(sizeBefore / rootCurrent) * 100}%`;
+        panelAfter.style[side] = `${((combined - sizeBefore) / rootCurrent) * 100}%`;
+      };
+
+      const move = (pxDelta: number) => {
         const panelBeforeNew = panelBeforeCurrent + cumulativeDelta + pxDelta;
         const panelAfterNew = panelAfterCurrent - (cumulativeDelta + pxDelta);
 
@@ -153,130 +174,60 @@ const Resizable = ({
         // only update cumulativeDelta if new size is within range
         cumulativeDelta += pxDelta;
 
-        const beforeCb = readCallbacks(panelBeforeIndex);
-        const afterCb = readCallbacks(panelAfterIndex);
-
         // a snap transformer returns the size its panel should take; the other
-        // panel absorbs the difference so the pair still fills `combined`
+        // panel absorbs the difference (write derives it from `combined`)
         let sizeBefore = panelBeforeNew;
-        let sizeAfter = panelAfterNew;
-        if (beforeCb?.snap) {
-          sizeBefore = beforeCb.snap(panelBeforeNew);
-          sizeAfter = combined - sizeBefore;
-        } else if (afterCb?.snap) {
-          sizeAfter = afterCb.snap(panelAfterNew);
-          sizeBefore = combined - sizeAfter;
-        }
+        if (panelBeforeSnap) sizeBefore = panelBeforeSnap(panelBeforeNew);
+        else if (panelAfterSnap) sizeBefore = combined - panelAfterSnap(panelAfterNew);
 
-        panelBefore.style[keys.side] = `${(sizeBefore / rootCurrent) * 100}%`;
-        panelAfter.style[keys.side] = `${(sizeAfter / rootCurrent) * 100}%`;
+        write(sizeBefore);
 
         // read-only notifications get the raw pointer-tracked size (pre-snap)
-        beforeCb?.onResize?.(panelBeforeNew);
-        afterCb?.onResize?.(panelAfterNew);
+        panelBeforeOnResize?.(panelBeforeNew);
+        panelAfterOnResize?.(panelAfterNew);
       };
 
-      return { apply };
-    },
-    [keys],
-  );
-
-  const persist = useCallback(() => {
-    if (!persistKey || !scope.current) return;
-    const sizes: Record<string, string> = {};
-    for (const child of scope.current.children) {
-      if (!(child instanceof HTMLElement) || !child.hasAttribute("data-ui-resizable-panel"))
-        continue;
-      const id = child.getAttribute("data-ui-resizable-panel");
-      if (id !== null) sizes[id] = child.style[keys.side];
-    }
-    try {
-      localStorage.setItem(getLocalstorageKey(persistKey), JSON.stringify(sizes));
-    } catch {
-      // ignore localStorage errors
-    }
-  }, [persistKey, keys.side]);
-
-  // Set a panel's size imperatively (outside a drag). The adjacent panel absorbs
-  // the difference so the pair still fills the space they share.
-  const resizePanel = useCallback(
-    (index: number, size: number) => {
-      const root = scope.current;
-      if (!root) return;
-
-      const panel = root.querySelector<HTMLElement>(`[data-ui-resizable-panel="${index}"]`);
-      if (!panel) return;
-
-      const findNeighbour = (dir: "next" | "previous") => {
-        let el = (
-          dir === "next" ? panel.nextElementSibling : panel.previousElementSibling
-        ) as HTMLElement | null;
-        while (el && !el.hasAttribute("data-ui-resizable-panel")) {
-          el = (
-            dir === "next" ? el.nextElementSibling : el.previousElementSibling
-          ) as HTMLElement | null;
-        }
-        return el;
+      // set the leading panel to an absolute size, clamped to its range; no snap
+      // or onResize (this is an imperative resize, not a drag)
+      const set = (size: number) => {
+        write(clamp(panelBeforeRange.min, size, panelBeforeRange.max));
       };
 
-      const neighbour = findNeighbour("next") ?? findNeighbour("previous");
-      if (!neighbour) return;
-
-      const rootCurrent = root[keys.sideOffset];
-      const combined =
-        panel.getBoundingClientRect()[keys.side] + neighbour.getBoundingClientRect()[keys.side];
-      const clamped = Math.max(0, Math.min(size, combined));
-
-      panel.style[keys.side] = `${(clamped / rootCurrent) * 100}%`;
-      neighbour.style[keys.side] = `${((combined - clamped) / rootCurrent) * 100}%`;
-
-      persist();
+      return { move, set, commit: persist };
     },
-    [keys, persist],
+    [orientation, persist],
   );
 
-  // normalize panel sizes on mount
+  // Normalize panel sizes on mount or restore persisted sizes from localStorage
   useEffect(() => {
     const root = scope.current;
     if (!root) return;
 
-    const panels = Array.from(root.children).filter(
-      (child): child is HTMLElement =>
-        child instanceof HTMLElement && child.hasAttribute("data-ui-resizable-panel"),
-    );
+    const side = orientation === "horizontal" ? "width" : "height";
 
     let persistedSizes: Record<string, string> = {};
-    try {
-      const stored = persistKey && localStorage.getItem(getLocalstorageKey(persistKey));
-      if (stored) persistedSizes = JSON.parse(stored);
-    } catch {
-      // ignore malformed storage values
+    if (persistKey) {
+      try {
+        const stored = localStorage.getItem(persistKey);
+        if (stored) persistedSizes = JSON.parse(stored);
+      } catch {} // ignore malformed storage values
     }
 
-    const rootSize = root.getBoundingClientRect()[keys.side];
-    for (const panel of panels) {
-      const panelId = panel.getAttribute("data-ui-resizable-panel") || "0";
-      const size = panel.getBoundingClientRect()[keys.side];
+    const rootSize = root.getBoundingClientRect()[side];
+    for (const panel of root.querySelectorAll<HTMLElement>("& > [data-ui-resizable-panel]")) {
+      const panelId = panel.getAttribute("data-ui-resizable-panel") || "unknown";
+      const size = panel.getBoundingClientRect()[side];
       const persistedSize = persistedSizes[panelId];
 
       // defer applying the size so subsequent panel size look-ups are accurate to the initial sizes
       window.requestAnimationFrame(() => {
-        panel.style[keys.side] = persistedSize ? persistedSize : `${(size / rootSize) * 100}%`;
+        panel.style[side] = persistedSize ? persistedSize : `${(size / rootSize) * 100}%`;
       });
     }
-  }, [keys, persistKey]);
+  }, [orientation, persistKey]);
 
   return (
-    <ResizableContext
-      value={{
-        scope,
-        orientation,
-        createResizeHandler,
-        persist,
-        registerPanelCallbacks,
-        resizePanel,
-      }}
-    >
+    <ResizableContext value={{ orientation, registerPanel, createResizeHandler }}>
       <div
         ref={composeRefs(ref, scope)}
         className={cn(
@@ -286,20 +237,20 @@ const Resizable = ({
         )}
         {...props}
       >
-        <InstanceCounterProvider>{children}</InstanceCounterProvider>
+        {children}
       </div>
     </ResizableContext>
   );
 };
 
-type ResizablePanelHandle = {
+type ResizablePanelRef = {
   /** Set the panel's size in pixels. The adjacent panel absorbs the difference. */
   resize: (size: number) => void;
 };
 
 type ResizablePanelProps = Omit<React.ComponentPropsWithRef<"div">, "ref"> & {
   /** Imperative handle to set this panel's size programmatically. */
-  ref?: React.Ref<ResizablePanelHandle>;
+  ref?: React.Ref<ResizablePanelRef>;
   asChild?: boolean;
   /**
    * Transform the panel's size during a resize: receives the pointer-tracked
@@ -313,34 +264,49 @@ type ResizablePanelProps = Omit<React.ComponentPropsWithRef<"div">, "ref"> & {
 
 const ResizablePanel = ({
   asChild,
+  ref: propRef,
   snap,
   onResize,
-  ref,
   className,
   children,
   ...props
 }: ResizablePanelProps) => {
-  const index = useInstanceCounter();
-  const { registerPanelCallbacks, resizePanel } = useResizableContext();
+  const { registerPanel, createResizeHandler } = useResizableContext();
+  const id = useId();
+  const ref = useRef<HTMLDivElement>(null);
 
-  useImperativeHandle(
-    ref,
-    (): ResizablePanelHandle => ({ resize: (size) => resizePanel(index, size) }),
-    [index, resizePanel],
-  );
+  // Expose imperative handle
+  useImperativeHandle(propRef, () => ({
+    resize: (size) => {
+      const element = ref.current;
+      if (!element) return;
+
+      const oppositePanel =
+        findAdjacentPanel(element, "next") ?? findAdjacentPanel(element, "previous");
+      if (!oppositePanel) return;
+
+      const handler = createResizeHandler(element, oppositePanel);
+      handler.set(size);
+      handler.commit();
+    },
+  }));
 
   useEffect(() => {
-    if (!snap && !onResize) return;
-    const unregister = registerPanelCallbacks(index, { snap, onResize });
-    return () => {
-      unregister();
-    };
-  }, [index, snap, onResize, registerPanelCallbacks]);
+    const element = ref.current;
+    if (!element) return;
+
+    return registerPanel(element, {
+      id,
+      snap,
+      onResize,
+    });
+  }, [registerPanel, id, snap, onResize]);
 
   const Component = asChild ? Slot : "div";
   return (
     <Component
-      data-ui-resizable-panel={index}
+      ref={ref}
+      data-ui-resizable-panel={id}
       className={cn("min-h-0 w-full min-w-0 grow overflow-auto", className)}
       {...props}
     >
@@ -353,32 +319,24 @@ type ResizableHandleProps = Omit<React.ComponentPropsWithRef<"div">, "children">
 
 const ResizableHandle = ({
   className,
-  ref,
+  ref: propRef,
   onPointerDown,
   onKeyDown,
   onFocus,
   onBlur,
   ...props
 }: ResizableHandleProps) => {
-  const { orientation, createResizeHandler, persist } = useResizableContext();
-  const handleRef = useRef<HTMLDivElement>(null);
-  const keyHandleRef = useRef<ResizeHandler | null>(null);
+  const { orientation, createResizeHandler } = useResizableContext();
+  const ref = useRef<HTMLDivElement>(null);
+  const keyHandlerRef = useRef<ResizeHandler | null>(null);
 
   const getAdjacentPanels = () => {
-    const el = handleRef.current;
-    if (!el) return { panelBefore: null, panelAfter: null };
-
-    let panelBefore = el.previousElementSibling as HTMLElement | null;
-    while (panelBefore && !panelBefore.hasAttribute("data-ui-resizable-panel")) {
-      panelBefore = panelBefore.previousElementSibling as HTMLElement | null;
-    }
-
-    let panelAfter = el.nextElementSibling as HTMLElement | null;
-    while (panelAfter && !panelAfter.hasAttribute("data-ui-resizable-panel")) {
-      panelAfter = panelAfter.nextElementSibling as HTMLElement | null;
-    }
-
-    return { panelBefore, panelAfter };
+    const element = ref.current;
+    if (!element) return { panelBefore: null, panelAfter: null };
+    return {
+      panelBefore: findAdjacentPanel(element, "previous"),
+      panelAfter: findAdjacentPanel(element, "next"),
+    };
   };
 
   const handlePointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
@@ -390,6 +348,7 @@ const ResizableHandle = ({
 
     const clientOffset = orientation === "horizontal" ? "clientX" : "clientY";
     const startOffset = event[clientOffset];
+
     const handler = createResizeHandler(panelBefore, panelAfter);
 
     const prevCursor = document.body.style.cursor;
@@ -401,14 +360,15 @@ const ResizableHandle = ({
     const onDrag = ({ [clientOffset]: offset }: PointerEvent) => {
       const currentDelta = offset - startOffset - previousDelta;
       previousDelta = offset - startOffset;
-      handler.apply(currentDelta);
+      handler.move(currentDelta);
     };
 
     const onDragEnd = () => {
       document.body.style.cursor = prevCursor;
       document.body.style.userSelect = prevUserSelect;
       window.removeEventListener("pointermove", onDrag);
-      persist();
+
+      handler.commit();
     };
 
     window.addEventListener("pointermove", onDrag);
@@ -420,37 +380,38 @@ const ResizableHandle = ({
     onFocus?.(e);
     if (e.defaultPrevented) return;
 
-    if (keyHandleRef.current) return;
+    if (keyHandlerRef.current) return;
     const { panelBefore, panelAfter } = getAdjacentPanels();
     if (!panelBefore || !panelAfter) return;
-    keyHandleRef.current = createResizeHandler(panelBefore, panelAfter);
+    keyHandlerRef.current = createResizeHandler(panelBefore, panelAfter);
   };
 
   const handleBlur: FocusEventHandler<HTMLDivElement> = (e) => {
     onBlur?.(e);
     if (e.defaultPrevented) return;
 
-    persist();
-    keyHandleRef.current = null;
+    keyHandlerRef.current?.commit();
+    keyHandlerRef.current = null;
   };
 
   const handleKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
     onKeyDown?.(event);
     if (event.defaultPrevented) return;
 
-    const handler = keyHandleRef.current;
+    const handler = keyHandlerRef.current;
     if (!handler) return;
 
     const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
     const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
+
     if (event.key === forward) {
       event.preventDefault();
-      return handler.apply(KEYBOARD_ARROW_PX_STEP);
+      return handler.move(KEYBOARD_ARROW_PX_STEP);
     }
 
     if (event.key === back) {
       event.preventDefault();
-      return handler.apply(-KEYBOARD_ARROW_PX_STEP);
+      return handler.move(-KEYBOARD_ARROW_PX_STEP);
     }
   };
 
@@ -461,7 +422,7 @@ const ResizableHandle = ({
       role="separator"
       aria-orientation={orientation === "horizontal" ? "vertical" : "horizontal"}
       tabIndex={0}
-      ref={composeRefs(ref, handleRef)}
+      ref={composeRefs(ref, propRef)}
       className={cn(
         "relative touch-none border-border outline-none ring-ring",
         "hover:border-foreground/24 hover:border-dashed active:border-foreground/48 active:border-dashed",
@@ -489,7 +450,6 @@ const CompoundResizable = Object.assign(Resizable, {
 export {
   CompoundResizable as Resizable,
   type ResizableHandleProps,
-  type ResizablePanelHandle,
   type ResizablePanelProps,
   type ResizableProps,
 };

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -171,7 +171,7 @@ const ResizablePanel = ({ asChild, className, children, ...props }: ResizablePan
       {index !== 0 && <ResizableHandle index={index} />}
       <Component
         data-ui-resizable-panel=""
-        className={cn("w-full grow overflow-auto", className)}
+        className={cn("min-h-0 w-full min-w-0 grow overflow-auto", className)}
         {...props}
       >
         {children}

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -6,6 +6,7 @@ import {
   use,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
 } from "react";
@@ -40,6 +41,7 @@ type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
   registerPanelCallbacks: (index: number, callbacks: PanelCallbacks) => () => void;
+  resizePanel: (index: number, size: number) => void;
   createResizeHandler: (panelBefore: HTMLElement, panelAfter: HTMLElement) => ResizeHandler;
   persist: () => void;
 };
@@ -195,6 +197,44 @@ const Resizable = ({
     }
   }, [persistKey, keys.side]);
 
+  // Set a panel's size imperatively (outside a drag). The adjacent panel absorbs
+  // the difference so the pair still fills the space they share.
+  const resizePanel = useCallback(
+    (index: number, size: number) => {
+      const root = scope.current;
+      if (!root) return;
+
+      const panel = root.querySelector<HTMLElement>(`[data-ui-resizable-panel="${index}"]`);
+      if (!panel) return;
+
+      const findNeighbour = (dir: "next" | "previous") => {
+        let el = (
+          dir === "next" ? panel.nextElementSibling : panel.previousElementSibling
+        ) as HTMLElement | null;
+        while (el && !el.hasAttribute("data-ui-resizable-panel")) {
+          el = (
+            dir === "next" ? el.nextElementSibling : el.previousElementSibling
+          ) as HTMLElement | null;
+        }
+        return el;
+      };
+
+      const neighbour = findNeighbour("next") ?? findNeighbour("previous");
+      if (!neighbour) return;
+
+      const rootCurrent = root[keys.sideOffset];
+      const combined =
+        panel.getBoundingClientRect()[keys.side] + neighbour.getBoundingClientRect()[keys.side];
+      const clamped = Math.max(0, Math.min(size, combined));
+
+      panel.style[keys.side] = `${(clamped / rootCurrent) * 100}%`;
+      neighbour.style[keys.side] = `${((combined - clamped) / rootCurrent) * 100}%`;
+
+      persist();
+    },
+    [keys, persist],
+  );
+
   // normalize panel sizes on mount
   useEffect(() => {
     const root = scope.current;
@@ -228,7 +268,14 @@ const Resizable = ({
 
   return (
     <ResizableContext
-      value={{ scope, orientation, createResizeHandler, persist, registerPanelCallbacks }}
+      value={{
+        scope,
+        orientation,
+        createResizeHandler,
+        persist,
+        registerPanelCallbacks,
+        resizePanel,
+      }}
     >
       <div
         ref={composeRefs(ref, scope)}
@@ -245,7 +292,14 @@ const Resizable = ({
   );
 };
 
-type ResizablePanelProps = React.ComponentPropsWithRef<"div"> & {
+type ResizablePanelHandle = {
+  /** Set the panel's size in pixels. The adjacent panel absorbs the difference. */
+  resize: (size: number) => void;
+};
+
+type ResizablePanelProps = Omit<React.ComponentPropsWithRef<"div">, "ref"> & {
+  /** Imperative handle to set this panel's size programmatically. */
+  ref?: React.Ref<ResizablePanelHandle>;
   asChild?: boolean;
   /**
    * Transform the panel's size during a resize: receives the pointer-tracked
@@ -261,12 +315,19 @@ const ResizablePanel = ({
   asChild,
   snap,
   onResize,
+  ref,
   className,
   children,
   ...props
 }: ResizablePanelProps) => {
   const index = useInstanceCounter();
-  const { registerPanelCallbacks } = useResizableContext();
+  const { registerPanelCallbacks, resizePanel } = useResizableContext();
+
+  useImperativeHandle(
+    ref,
+    (): ResizablePanelHandle => ({ resize: (size) => resizePanel(index, size) }),
+    [index, resizePanel],
+  );
 
   useEffect(() => {
     if (!snap && !onResize) return;
@@ -428,6 +489,7 @@ const CompoundResizable = Object.assign(Resizable, {
 export {
   CompoundResizable as Resizable,
   type ResizableHandleProps,
+  type ResizablePanelHandle,
   type ResizablePanelProps,
   type ResizableProps,
 };

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -77,21 +77,20 @@ const Resizable = ({
       const panelAfterCurrent = panelAfter.getBoundingClientRect()[keys.side];
 
       const calcPanelRange = (panel: HTMLElement, oppositePanel: HTMLElement) => {
-        const key = orientation === "horizontal" ? "width" : "height";
         const previousStyles = {
-          panel: panel.style[key],
-          oppositePanel: oppositePanel.style[key],
+          panel: panel.style[keys.side],
+          oppositePanel: oppositePanel.style[keys.side],
         };
 
-        panel.style[key] = "0rem";
-        oppositePanel.style[key] = "999rem";
-        const min = panel.getBoundingClientRect()[key];
-        panel.style[key] = "999rem";
-        oppositePanel.style[key] = "0rem";
-        const max = panel.getBoundingClientRect()[key];
+        panel.style[keys.side] = "0rem";
+        oppositePanel.style[keys.side] = "999rem";
+        const min = panel.getBoundingClientRect()[keys.side];
+        panel.style[keys.side] = "999rem";
+        oppositePanel.style[keys.side] = "0rem";
+        const max = panel.getBoundingClientRect()[keys.side];
 
-        panel.style[key] = previousStyles.panel;
-        oppositePanel.style[key] = previousStyles.oppositePanel;
+        panel.style[keys.side] = previousStyles.panel;
+        oppositePanel.style[keys.side] = previousStyles.oppositePanel;
 
         return { min, max };
       };
@@ -116,7 +115,7 @@ const Resizable = ({
 
       return { apply };
     },
-    [keys, orientation],
+    [keys],
   );
 
   // init and memo panels
@@ -125,13 +124,14 @@ const Resizable = ({
     if (!root) return;
 
     panels.current = [...root.querySelectorAll<HTMLElement>("[data-ui-resizable-panel]")];
+    const rootSize = root.getBoundingClientRect()[keys.side];
 
     // Normalize panels widths: each panel gets fraction of the total width
     for (const panel of panels.current) {
-      const size = panel[keys.sideOffset];
+      const size = panel.getBoundingClientRect()[keys.side];
 
       setTimeout(() => {
-        panel.style.width = `${(size / root.offsetWidth) * 100}%`;
+        panel.style[keys.side] = `${(size / rootSize) * 100}%`;
       }, 0);
     }
   }, [keys]);
@@ -141,7 +141,7 @@ const Resizable = ({
       <div
         ref={composeRefs(ref, scope)}
         className={cn(
-          "flex overflow-hidden",
+          "flex min-h-0 min-w-0 overflow-hidden",
           orientation === "horizontal" ? "flex-row" : "flex-col",
           className,
         )}
@@ -157,7 +157,7 @@ type ResizablePanelProps = React.ComponentPropsWithRef<"div"> & {
   asChild?: boolean;
 };
 
-const ResizablePanel = ({ asChild, className, style, children, ...props }: ResizablePanelProps) => {
+const ResizablePanel = ({ asChild, className, children, ...props }: ResizablePanelProps) => {
   const index = useInstanceCounter();
 
   const Component = asChild ? Slot : "div";
@@ -188,12 +188,19 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
     const startOffset = event[clientOffset];
     const handler = createResizeHandler(index);
 
+    const prevCursor = document.body.style.cursor;
+    const prevUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = orientation === "horizontal" ? "col-resize" : "row-resize";
+    document.body.style.userSelect = "none";
+
     const onDrag = ({ [clientOffset]: offset }: PointerEvent) => {
       const delta = offset - startOffset;
       handler.apply(delta);
     };
 
     const onDragEnd = () => {
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevUserSelect;
       window.removeEventListener("pointermove", onDrag);
     };
 

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -1,0 +1,240 @@
+import {
+  createContext,
+  type KeyboardEventHandler,
+  type PointerEventHandler,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import {
+  InstanceCounterProvider,
+  useInstanceCounter,
+} from "@/foundations/components/instance-counter/instance-counter";
+import { Slot } from "@/foundations/components/slot/slot";
+import { composeRefs } from "@/foundations/utils/compose-refs/compose-refs";
+import { clamp } from "@/foundations/utils/math/clamp";
+import { cn } from "@/lib/utils/classnames";
+
+type Orientation = "horizontal" | "vertical";
+
+const getElementDimensionRange = (element: HTMLElement, orientation: Orientation) => {
+  const key = orientation === "horizontal" ? "width" : "height";
+  const previous = element.style[key];
+
+  element.style[key] = "0";
+  const min = element.getBoundingClientRect()[key];
+  element.style[key] = "100%";
+  const max = element.getBoundingClientRect()[key];
+
+  element.style[key] = previous;
+
+  return { min, max };
+};
+
+type ResizeHandler = (index: number) => {
+  apply: (pxDelta: number) => void;
+};
+
+type ResizableContextValue = {
+  orientation: Orientation;
+  scope: React.RefObject<HTMLDivElement | null>;
+  createResizeHandler: ResizeHandler;
+};
+
+const ResizableContext = createContext<ResizableContextValue | null>(null);
+
+const useResizableContext = () => {
+  const context = use(ResizableContext);
+  if (!context) throw new Error("Resizable components must be used within a Resizable");
+  return context;
+};
+
+type ResizableProps = Omit<React.ComponentPropsWithRef<"div">, "onResize"> & {
+  orientation?: Orientation;
+  children: React.ReactNode;
+};
+
+const Resizable = ({
+  orientation = "horizontal",
+  className,
+  children,
+  ref,
+  ...props
+}: ResizableProps) => {
+  const scope = useRef<HTMLDivElement>(null);
+  const panels = useRef<HTMLElement[]>([]);
+
+  const keys = useMemo(() => {
+    return {
+      side: orientation === "horizontal" ? "width" : "height",
+      sideOffset: orientation === "horizontal" ? "offsetWidth" : "offsetHeight",
+      clientOffset: orientation === "horizontal" ? "clientX" : "clientY",
+    } as const;
+  }, [orientation]);
+
+  const createResizeHandler: ResizeHandler = useCallback(
+    (index: number) => {
+      const root = scope.current;
+      const panelBefore = panels.current[index - 1];
+      const panelAfter = panels.current[index];
+
+      if (!root || !panelBefore || !panelAfter) {
+        return { apply: () => undefined };
+      }
+
+      // sizes when drag started
+      const rootCurrent = root[keys.sideOffset];
+      const panelBeforeCurrent = panelBefore[keys.sideOffset];
+      const panelAfterCurrent = panelAfter[keys.sideOffset];
+
+      // size range for each panel
+      const panelBeforeRange = getElementDimensionRange(panelBefore, orientation);
+      const panelAfterRange = getElementDimensionRange(panelAfter, orientation);
+
+      const apply = (pxDelta: number) => {
+        const panelBeforeNew = clamp(
+          panelBeforeRange.min,
+          panelBeforeCurrent + pxDelta,
+          panelBeforeRange.max,
+        );
+        const panelAfterNew = clamp(
+          panelAfterRange.min,
+          panelAfterCurrent - pxDelta,
+          panelAfterRange.max,
+        );
+
+        panelBefore.style[keys.side] = `${(panelBeforeNew / rootCurrent) * 100}%`;
+        panelAfter.style[keys.side] = `${(panelAfterNew / rootCurrent) * 100}%`;
+      };
+
+      return { apply };
+    },
+    [keys, orientation],
+  );
+
+  // init and memo panels
+  useEffect(() => {
+    const root = scope.current;
+    if (!root) return;
+
+    panels.current = [...root.querySelectorAll<HTMLElement>("[data-ui-resizable-panel]")];
+
+    // Normalize panels widths: each panel gets fraction of the total width
+    for (const panel of panels.current) {
+      const size = panel[keys.sideOffset];
+      setTimeout(() => {
+        panel.style.width = `${(size / root.offsetWidth) * 100}%`;
+      }, 0);
+    }
+  }, [keys]);
+
+  return (
+    <ResizableContext value={{ scope, orientation, createResizeHandler }}>
+      <div
+        ref={composeRefs(ref, scope)}
+        className={cn(
+          "flex overflow-hidden",
+          orientation === "horizontal" ? "flex-row" : "flex-col",
+          className,
+        )}
+        {...props}
+      >
+        <InstanceCounterProvider>{children}</InstanceCounterProvider>
+      </div>
+    </ResizableContext>
+  );
+};
+
+type ResizablePanelProps = React.ComponentPropsWithRef<"div"> & {
+  asChild?: boolean;
+};
+
+const ResizablePanel = ({ asChild, className, style, children, ...props }: ResizablePanelProps) => {
+  const index = useInstanceCounter();
+
+  const Component = asChild ? Slot : "div";
+  return (
+    <>
+      {/* Every panel but the first owns the handle on its leading edge. */}
+      {index !== 0 && <ResizableHandle index={index} />}
+      <Component
+        data-ui-resizable-panel=""
+        className={cn("w-full overflow-auto", className)}
+        {...props}
+      >
+        {children}
+      </Component>
+    </>
+  );
+};
+
+type ResizableHandleProps = {
+  index: number;
+};
+
+const ResizableHandle = ({ index }: ResizableHandleProps) => {
+  const { orientation, createResizeHandler } = useResizableContext();
+
+  const onPointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
+    const clientOffset = orientation === "horizontal" ? "clientX" : "clientY";
+    const startOffset = event[clientOffset];
+    const handler = createResizeHandler(index);
+
+    const onDrag = ({ [clientOffset]: offset }: PointerEvent) => {
+      const delta = offset - startOffset;
+      handler.apply(delta);
+    };
+
+    const onDragEnd = () => {
+      window.removeEventListener("pointermove", onDrag);
+    };
+
+    window.addEventListener("pointermove", onDrag);
+    window.addEventListener("pointerup", onDragEnd, { once: true });
+  };
+
+  const onKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
+    const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
+
+    const handler = createResizeHandler(index);
+
+    if (event.key === forward) {
+      event.preventDefault();
+      return handler.apply(10);
+    }
+
+    if (event.key === back) {
+      event.preventDefault();
+      return handler.apply(-10);
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: hr element does not support after pseudo element
+    <div
+      // biome-ignore lint/a11y/useAriaPropsForRole: hr element does not support after pseudo element
+      role="separator"
+      aria-orientation={orientation}
+      tabIndex={0}
+      className={cn(
+        "relative border-border border-l",
+        "hover:border-foreground/24 hover:border-dashed active:border-foreground/48 active:border-dashed",
+        "after:absolute after:inset-0",
+        orientation === "horizontal"
+          ? "h-full w-px cursor-col-resize border-l after:-inset-x-2"
+          : "h-px w-full cursor-row-resize border-t after:-inset-y-2",
+      )}
+      onPointerDown={onPointerDown}
+      onKeyDown={onKeydown}
+    />
+  );
+};
+
+const CompoundResizable = Object.assign(Resizable, {
+  Panel: ResizablePanel,
+});
+
+export { CompoundResizable as Resizable, type ResizablePanelProps, type ResizableProps };

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -105,6 +105,9 @@ const Resizable = ({
       const panelBeforeRange = calcPanelRange(panelBefore, panelAfter);
       const panelAfterRange = calcPanelRange(panelAfter, panelBefore);
 
+      // store how much we've moved so far (in px)
+      // so we can easily calculate the new size from the current size
+      // and thereby avoid size look-ups during apply (i.e. during drag)
       let cumulativeDelta = 0;
 
       const apply = (pxDelta: number) => {

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -28,12 +28,18 @@ type ResizeHandler = {
   apply: (pxDelta: number) => void;
 };
 
-type PanelOnResizeCallback = (size: number, setSize: (size: number) => void) => void;
+type PanelCallbacks = {
+  // Transform the panel's size during a resize — return the size (px) it should
+  // take. Runs every frame, so it can pin/snap (e.g. collapse) the panel.
+  snap?: (size: number) => number;
+  // Read-only notification with the pointer-tracked size (px) during a resize.
+  onResize?: (size: number) => void;
+};
 
 type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
-  registerPanelCallback: (index: number, callback: PanelOnResizeCallback) => () => void;
+  registerPanelCallbacks: (index: number, callbacks: PanelCallbacks) => () => void;
   createResizeHandler: (panelBefore: HTMLElement, panelAfter: HTMLElement) => ResizeHandler;
   persist: () => void;
 };
@@ -61,10 +67,10 @@ const Resizable = ({
   ...props
 }: ResizableProps) => {
   const scope = useRef<HTMLDivElement>(null);
-  const panelCallbacks = useRef<(PanelOnResizeCallback | null)[]>([]);
+  const panelCallbacks = useRef<(PanelCallbacks | null)[]>([]);
 
-  const registerPanelCallback = useCallback((index: number, callback: PanelOnResizeCallback) => {
-    panelCallbacks.current[index] = callback;
+  const registerPanelCallbacks = useCallback((index: number, callbacks: PanelCallbacks) => {
+    panelCallbacks.current[index] = callbacks;
     return () => {
       panelCallbacks.current[index] = null;
     };
@@ -91,12 +97,10 @@ const Resizable = ({
         panelAfter.getAttribute("data-ui-resizable-panel") ?? "",
         10,
       );
-      const panelBeforeCallback = Number.isNaN(panelBeforeIndex)
-        ? null
-        : (panelCallbacks.current[panelBeforeIndex] ?? null);
-      const panelAfterCallback = Number.isNaN(panelAfterIndex)
-        ? null
-        : (panelCallbacks.current[panelAfterIndex] ?? null);
+      // read a panel's registered callbacks fresh each frame (the panel may
+      // re-register mid-drag when its snap/onResize identity changes)
+      const readCallbacks = (index: number) =>
+        Number.isNaN(index) ? null : (panelCallbacks.current[index] ?? null);
 
       // sizes when drag started
       const rootCurrent = root[keys.sideOffset];
@@ -131,11 +135,8 @@ const Resizable = ({
       // and thereby avoid size look-ups during apply (i.e. during drag)
       let cumulativeDelta = 0;
 
-      const setPanelSize = (panel: HTMLElement, oppositePanel: HTMLElement, size: number) => {
-        const otherSize = panelBeforeCurrent + panelAfterCurrent - size;
-        panel.style[keys.side] = `${(size / rootCurrent) * 100}%`;
-        oppositePanel.style[keys.side] = `${(otherSize / rootCurrent) * 100}%`;
-      };
+      // the space the two panels share stays constant during a drag
+      const combined = panelBeforeCurrent + panelAfterCurrent;
 
       const apply = (pxDelta: number) => {
         const panelBeforeNew = panelBeforeCurrent + cumulativeDelta + pxDelta;
@@ -150,15 +151,27 @@ const Resizable = ({
         // only update cumulativeDelta if new size is within range
         cumulativeDelta += pxDelta;
 
-        panelBefore.style[keys.side] = `${(panelBeforeNew / rootCurrent) * 100}%`;
-        panelAfter.style[keys.side] = `${(panelAfterNew / rootCurrent) * 100}%`;
+        const beforeCb = readCallbacks(panelBeforeIndex);
+        const afterCb = readCallbacks(panelAfterIndex);
 
-        panelBeforeCallback?.(panelBeforeNew, (newSize) =>
-          setPanelSize(panelBefore, panelAfter, newSize),
-        );
-        panelAfterCallback?.(panelAfterNew, (newSize) =>
-          setPanelSize(panelAfter, panelBefore, newSize),
-        );
+        // a snap transformer returns the size its panel should take; the other
+        // panel absorbs the difference so the pair still fills `combined`
+        let sizeBefore = panelBeforeNew;
+        let sizeAfter = panelAfterNew;
+        if (beforeCb?.snap) {
+          sizeBefore = beforeCb.snap(panelBeforeNew);
+          sizeAfter = combined - sizeBefore;
+        } else if (afterCb?.snap) {
+          sizeAfter = afterCb.snap(panelAfterNew);
+          sizeBefore = combined - sizeAfter;
+        }
+
+        panelBefore.style[keys.side] = `${(sizeBefore / rootCurrent) * 100}%`;
+        panelAfter.style[keys.side] = `${(sizeAfter / rootCurrent) * 100}%`;
+
+        // read-only notifications get the raw pointer-tracked size (pre-snap)
+        beforeCb?.onResize?.(panelBeforeNew);
+        afterCb?.onResize?.(panelAfterNew);
       };
 
       return { apply };
@@ -215,7 +228,7 @@ const Resizable = ({
 
   return (
     <ResizableContext
-      value={{ scope, orientation, createResizeHandler, persist, registerPanelCallback }}
+      value={{ scope, orientation, createResizeHandler, persist, registerPanelCallbacks }}
     >
       <div
         ref={composeRefs(ref, scope)}
@@ -234,27 +247,34 @@ const Resizable = ({
 
 type ResizablePanelProps = React.ComponentPropsWithRef<"div"> & {
   asChild?: boolean;
-  onResize?: PanelOnResizeCallback;
+  /**
+   * Transform the panel's size during a resize: receives the pointer-tracked
+   * size in px and returns the size the panel should take. Runs every frame, so
+   * it can snap or collapse the panel. Return the size unchanged for a no-op.
+   */
+  snap?: (size: number) => number;
+  /** Read-only notification fired during drag/keyboard resize with the size in px. */
+  onResize?: (size: number) => void;
 };
 
 const ResizablePanel = ({
   asChild,
+  snap,
   onResize,
   className,
   children,
   ...props
 }: ResizablePanelProps) => {
   const index = useInstanceCounter();
-  const { registerPanelCallback } = useResizableContext();
+  const { registerPanelCallbacks } = useResizableContext();
 
   useEffect(() => {
-    if (onResize) {
-      const unregister = registerPanelCallback(index, onResize);
-      return () => {
-        unregister();
-      };
-    }
-  }, [index, onResize, registerPanelCallback]);
+    if (!snap && !onResize) return;
+    const unregister = registerPanelCallbacks(index, { snap, onResize });
+    return () => {
+      unregister();
+    };
+  }, [index, snap, onResize, registerPanelCallbacks]);
 
   const Component = asChild ? Slot : "div";
   return (

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  type FocusEventHandler,
   type KeyboardEventHandler,
   type PointerEventHandler,
   use,
@@ -33,7 +34,7 @@ type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
   registerPanelCallback: (index: number, callback: PanelOnResizeCallback) => () => void;
-  createResizeHandler: (index: number) => ResizeHandler;
+  createResizeHandler: (panelBefore: HTMLElement, panelAfter: HTMLElement) => ResizeHandler;
   persist: () => void;
 };
 
@@ -60,12 +61,10 @@ const Resizable = ({
   ...props
 }: ResizableProps) => {
   const scope = useRef<HTMLDivElement>(null);
-  const panels = useRef<HTMLElement[]>([]);
   const panelCallbacks = useRef<(PanelOnResizeCallback | null)[]>([]);
 
   const registerPanelCallback = useCallback((index: number, callback: PanelOnResizeCallback) => {
     panelCallbacks.current[index] = callback;
-
     return () => {
       panelCallbacks.current[index] = null;
     };
@@ -80,18 +79,24 @@ const Resizable = ({
   }, [orientation]);
 
   const createResizeHandler = useCallback(
-    (handleIndex: number) => {
+    (panelBefore: HTMLElement, panelAfter: HTMLElement) => {
       const root = scope.current;
-      const panelBeforeIndex = handleIndex - 1;
-      const panelAfterIndex = handleIndex;
-      const panelBefore = panels.current[panelBeforeIndex];
-      const panelAfter = panels.current[panelAfterIndex];
-      const panelBeforeCallback = panelCallbacks.current[panelBeforeIndex];
-      const panelAfterCallback = panelCallbacks.current[panelAfterIndex];
+      if (!root) return { apply: () => undefined };
 
-      if (!root || !panelBefore || !panelAfter) {
-        return { apply: () => undefined };
-      }
+      const panelBeforeIndex = parseInt(
+        panelBefore.getAttribute("data-ui-resizable-panel") ?? "",
+        10,
+      );
+      const panelAfterIndex = parseInt(
+        panelAfter.getAttribute("data-ui-resizable-panel") ?? "",
+        10,
+      );
+      const panelBeforeCallback = Number.isNaN(panelBeforeIndex)
+        ? null
+        : (panelCallbacks.current[panelBeforeIndex] ?? null);
+      const panelAfterCallback = Number.isNaN(panelAfterIndex)
+        ? null
+        : (panelCallbacks.current[panelAfterIndex] ?? null);
 
       // sizes when drag started
       const rootCurrent = root[keys.sideOffset];
@@ -128,7 +133,6 @@ const Resizable = ({
 
       const setPanelSize = (panel: HTMLElement, oppositePanel: HTMLElement, size: number) => {
         const otherSize = panelBeforeCurrent + panelAfterCurrent - size;
-
         panel.style[keys.side] = `${(size / rootCurrent) * 100}%`;
         oppositePanel.style[keys.side] = `${(otherSize / rootCurrent) * 100}%`;
       };
@@ -163,11 +167,13 @@ const Resizable = ({
   );
 
   const persist = useCallback(() => {
-    if (!persistKey) return;
+    if (!persistKey || !scope.current) return;
     const sizes: Record<string, string> = {};
-    for (const panel of panels.current) {
-      const id = panel.getAttribute("data-ui-resizable-panel");
-      if (id !== null) sizes[id] = panel.style[keys.side];
+    for (const child of scope.current.children) {
+      if (!(child instanceof HTMLElement) || !child.hasAttribute("data-ui-resizable-panel"))
+        continue;
+      const id = child.getAttribute("data-ui-resizable-panel");
+      if (id !== null) sizes[id] = child.style[keys.side];
     }
     try {
       localStorage.setItem(getLocalstorageKey(persistKey), JSON.stringify(sizes));
@@ -176,12 +182,12 @@ const Resizable = ({
     }
   }, [persistKey, keys.side]);
 
-  // init and memo panels
+  // normalize panel sizes on mount
   useEffect(() => {
     const root = scope.current;
     if (!root) return;
 
-    panels.current = Array.from(root.children).filter(
+    const panels = Array.from(root.children).filter(
       (child): child is HTMLElement =>
         child instanceof HTMLElement && child.hasAttribute("data-ui-resizable-panel"),
     );
@@ -194,9 +200,8 @@ const Resizable = ({
       // ignore malformed storage values
     }
 
-    // Normalize panels widths: each panel gets fraction of the total width
     const rootSize = root.getBoundingClientRect()[keys.side];
-    for (const panel of panels.current) {
+    for (const panel of panels) {
       const panelId = panel.getAttribute("data-ui-resizable-panel") || "0";
       const size = panel.getBoundingClientRect()[keys.side];
       const persistedSize = persistedSizes[panelId];
@@ -245,7 +250,6 @@ const ResizablePanel = ({
   useEffect(() => {
     if (onResize) {
       const unregister = registerPanelCallback(index, onResize);
-
       return () => {
         unregister();
       };
@@ -254,32 +258,58 @@ const ResizablePanel = ({
 
   const Component = asChild ? Slot : "div";
   return (
-    <>
-      {/* Every panel but the first owns the handle on its leading edge. */}
-      {index !== 0 && <ResizableHandle index={index} />}
-      <Component
-        data-ui-resizable-panel={index}
-        className={cn("min-h-0 w-full min-w-0 grow overflow-auto", className)}
-        {...props}
-      >
-        {children}
-      </Component>
-    </>
+    <Component
+      data-ui-resizable-panel={index}
+      className={cn("min-h-0 w-full min-w-0 grow overflow-auto", className)}
+      {...props}
+    >
+      {children}
+    </Component>
   );
 };
 
-type ResizableHandleProps = {
-  index: number;
-};
+type ResizableHandleProps = Omit<React.ComponentPropsWithRef<"div">, "children">;
 
-const ResizableHandle = ({ index }: ResizableHandleProps) => {
+const ResizableHandle = ({
+  className,
+  ref,
+  onPointerDown,
+  onKeyDown,
+  onFocus,
+  onBlur,
+  ...props
+}: ResizableHandleProps) => {
   const { orientation, createResizeHandler, persist } = useResizableContext();
+  const handleRef = useRef<HTMLDivElement>(null);
   const keyHandleRef = useRef<ResizeHandler | null>(null);
 
-  const onPointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
+  const getAdjacentPanels = () => {
+    const el = handleRef.current;
+    if (!el) return { panelBefore: null, panelAfter: null };
+
+    let panelBefore = el.previousElementSibling as HTMLElement | null;
+    while (panelBefore && !panelBefore.hasAttribute("data-ui-resizable-panel")) {
+      panelBefore = panelBefore.previousElementSibling as HTMLElement | null;
+    }
+
+    let panelAfter = el.nextElementSibling as HTMLElement | null;
+    while (panelAfter && !panelAfter.hasAttribute("data-ui-resizable-panel")) {
+      panelAfter = panelAfter.nextElementSibling as HTMLElement | null;
+    }
+
+    return { panelBefore, panelAfter };
+  };
+
+  const handlePointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
+    onPointerDown?.(event);
+    if (event.defaultPrevented) return;
+
+    const { panelBefore, panelAfter } = getAdjacentPanels();
+    if (!panelBefore || !panelAfter) return;
+
     const clientOffset = orientation === "horizontal" ? "clientX" : "clientY";
     const startOffset = event[clientOffset];
-    const handler = createResizeHandler(index);
+    const handler = createResizeHandler(panelBefore, panelAfter);
 
     const prevCursor = document.body.style.cursor;
     const prevUserSelect = document.body.style.userSelect;
@@ -305,16 +335,28 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
     window.addEventListener("pointercancel", onDragEnd, { once: true });
   };
 
-  const onFocus = () => {
-    keyHandleRef.current = createResizeHandler(index);
+  const handleFocus: FocusEventHandler<HTMLDivElement> = (e) => {
+    onFocus?.(e);
+    if (e.defaultPrevented) return;
+
+    if (keyHandleRef.current) return;
+    const { panelBefore, panelAfter } = getAdjacentPanels();
+    if (!panelBefore || !panelAfter) return;
+    keyHandleRef.current = createResizeHandler(panelBefore, panelAfter);
   };
 
-  const onBlur = () => {
+  const handleBlur: FocusEventHandler<HTMLDivElement> = (e) => {
+    onBlur?.(e);
+    if (e.defaultPrevented) return;
+
     persist();
     keyHandleRef.current = null;
   };
 
-  const onKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+  const handleKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+
     const handler = keyHandleRef.current;
     if (!handler) return;
 
@@ -338,6 +380,7 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
       role="separator"
       aria-orientation={orientation === "horizontal" ? "vertical" : "horizontal"}
       tabIndex={0}
+      ref={composeRefs(ref, handleRef)}
       className={cn(
         "relative touch-none border-border outline-none ring-ring",
         "hover:border-foreground/24 hover:border-dashed active:border-foreground/48 active:border-dashed",
@@ -346,17 +389,25 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
         orientation === "horizontal"
           ? "h-full w-px cursor-col-resize border-l after:-inset-x-2"
           : "h-px w-full cursor-row-resize border-t after:-inset-y-2",
+        className,
       )}
-      onPointerDown={onPointerDown}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onKeyDown={onKeydown}
+      onPointerDown={handlePointerDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyDown={handleKeydown}
+      {...props}
     />
   );
 };
 
 const CompoundResizable = Object.assign(Resizable, {
   Panel: ResizablePanel,
+  Handle: ResizableHandle,
 });
 
-export { CompoundResizable as Resizable, type ResizablePanelProps, type ResizableProps };
+export {
+  CompoundResizable as Resizable,
+  type ResizableHandleProps,
+  type ResizablePanelProps,
+  type ResizableProps,
+};

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -27,9 +27,12 @@ type ResizeHandler = {
   apply: (pxDelta: number) => void;
 };
 
+type PanelOnResizeCallback = (size: number, setSize: (size: number) => void) => void;
+
 type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
+  registerPanelCallback: (index: number, callback: PanelOnResizeCallback) => () => void;
   createResizeHandler: (index: number) => ResizeHandler;
   persist: () => void;
 };
@@ -58,6 +61,15 @@ const Resizable = ({
 }: ResizableProps) => {
   const scope = useRef<HTMLDivElement>(null);
   const panels = useRef<HTMLElement[]>([]);
+  const panelCallbacks = useRef<(PanelOnResizeCallback | null)[]>([]);
+
+  const registerPanelCallback = useCallback((index: number, callback: PanelOnResizeCallback) => {
+    panelCallbacks.current[index] = callback;
+
+    return () => {
+      panelCallbacks.current[index] = null;
+    };
+  }, []);
 
   const keys = useMemo(() => {
     return {
@@ -70,8 +82,12 @@ const Resizable = ({
   const createResizeHandler = useCallback(
     (handleIndex: number) => {
       const root = scope.current;
-      const panelBefore = panels.current[handleIndex - 1];
-      const panelAfter = panels.current[handleIndex];
+      const panelBeforeIndex = handleIndex - 1;
+      const panelAfterIndex = handleIndex;
+      const panelBefore = panels.current[panelBeforeIndex];
+      const panelAfter = panels.current[panelAfterIndex];
+      const panelBeforeCallback = panelCallbacks.current[panelBeforeIndex];
+      const panelAfterCallback = panelCallbacks.current[panelAfterIndex];
 
       if (!root || !panelBefore || !panelAfter) {
         return { apply: () => undefined };
@@ -110,6 +126,13 @@ const Resizable = ({
       // and thereby avoid size look-ups during apply (i.e. during drag)
       let cumulativeDelta = 0;
 
+      const setPanelSize = (panel: HTMLElement, oppositePanel: HTMLElement, size: number) => {
+        const otherSize = panelBeforeCurrent + panelAfterCurrent - size;
+
+        panel.style[keys.side] = `${(size / rootCurrent) * 100}%`;
+        oppositePanel.style[keys.side] = `${(otherSize / rootCurrent) * 100}%`;
+      };
+
       const apply = (pxDelta: number) => {
         const panelBeforeNew = panelBeforeCurrent + cumulativeDelta + pxDelta;
         const panelAfterNew = panelAfterCurrent - (cumulativeDelta + pxDelta);
@@ -125,6 +148,13 @@ const Resizable = ({
 
         panelBefore.style[keys.side] = `${(panelBeforeNew / rootCurrent) * 100}%`;
         panelAfter.style[keys.side] = `${(panelAfterNew / rootCurrent) * 100}%`;
+
+        panelBeforeCallback?.(panelBeforeNew, (newSize) =>
+          setPanelSize(panelBefore, panelAfter, newSize),
+        );
+        panelAfterCallback?.(panelAfterNew, (newSize) =>
+          setPanelSize(panelAfter, panelBefore, newSize),
+        );
       };
 
       return { apply };
@@ -179,7 +209,9 @@ const Resizable = ({
   }, [keys, persistKey]);
 
   return (
-    <ResizableContext value={{ scope, orientation, createResizeHandler, persist }}>
+    <ResizableContext
+      value={{ scope, orientation, createResizeHandler, persist, registerPanelCallback }}
+    >
       <div
         ref={composeRefs(ref, scope)}
         className={cn(
@@ -197,10 +229,28 @@ const Resizable = ({
 
 type ResizablePanelProps = React.ComponentPropsWithRef<"div"> & {
   asChild?: boolean;
+  onResize?: PanelOnResizeCallback;
 };
 
-const ResizablePanel = ({ asChild, className, children, ...props }: ResizablePanelProps) => {
+const ResizablePanel = ({
+  asChild,
+  onResize,
+  className,
+  children,
+  ...props
+}: ResizablePanelProps) => {
   const index = useInstanceCounter();
+  const { registerPanelCallback } = useResizableContext();
+
+  useEffect(() => {
+    if (onResize) {
+      const unregister = registerPanelCallback(index, onResize);
+
+      return () => {
+        unregister();
+      };
+    }
+  }, [index, onResize, registerPanelCallback]);
 
   const Component = asChild ? Slot : "div";
   return (

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -16,7 +16,10 @@ import { Slot } from "@/foundations/components/slot/slot";
 import { composeRefs } from "@/foundations/utils/compose-refs/compose-refs";
 import { cn } from "@/lib/utils/classnames";
 
+// The number of pixels to move when using the keyboard to resize.
 const KEYBOARD_ARROW_PX_STEP = 10;
+
+const getLocalstorageKey = (id: string) => `foundations-ui:resizable-${id}`;
 
 type Orientation = "horizontal" | "vertical";
 
@@ -28,6 +31,7 @@ type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
   createResizeHandler: (index: number) => ResizeHandler;
+  persist: () => void;
 };
 
 const ResizableContext = createContext<ResizableContextValue | null>(null);
@@ -40,11 +44,13 @@ const useResizableContext = () => {
 
 type ResizableProps = Omit<React.ComponentPropsWithRef<"div">, "onResize"> & {
   orientation?: Orientation;
+  persist?: string;
   children: React.ReactNode;
 };
 
 const Resizable = ({
   orientation = "horizontal",
+  persist: persistKey,
   className,
   children,
   ref,
@@ -123,30 +129,55 @@ const Resizable = ({
     [keys],
   );
 
+  const persist = useCallback(() => {
+    if (!persistKey) return;
+    const sizes: Record<string, string> = {};
+    for (const panel of panels.current) {
+      const id = panel.getAttribute("data-ui-resizable-panel");
+      if (id !== null) sizes[id] = panel.style[keys.side];
+    }
+    localStorage.setItem(getLocalstorageKey(persistKey), JSON.stringify(sizes));
+  }, [persistKey, keys.side]);
+
   // init and memo panels
   useEffect(() => {
     const root = scope.current;
     if (!root) return;
-
-    const rootSize = root.getBoundingClientRect()[keys.side];
 
     panels.current = Array.from(root.children).filter(
       (child): child is HTMLElement =>
         child instanceof HTMLElement && child.hasAttribute("data-ui-resizable-panel"),
     );
 
-    // Normalize panels widths: each panel gets fraction of the total width
-    for (const panel of panels.current) {
-      const size = panel.getBoundingClientRect()[keys.side];
-
-      setTimeout(() => {
-        panel.style[keys.side] = `${(size / rootSize) * 100}%`;
-      }, 0);
+    let persistedSizes: Record<string, string> = {};
+    try {
+      const stored = persistKey && localStorage.getItem(getLocalstorageKey(persistKey));
+      if (stored) persistedSizes = JSON.parse(stored);
+    } catch {
+      // ignore malformed storage values
     }
-  }, [keys]);
+
+    // Normalize panels widths: each panel gets fraction of the total width
+    const rootSize = root.getBoundingClientRect()[keys.side];
+    for (const panel of panels.current) {
+      const panelId = panel.getAttribute("data-ui-resizable-panel") || "0";
+      const persistedSize = persistedSizes[panelId];
+
+      if (persistedSize) {
+        setTimeout(() => {
+          panel.style[keys.side] = persistedSize;
+        }, 0);
+      } else {
+        const size = panel.getBoundingClientRect()[keys.side];
+        setTimeout(() => {
+          panel.style[keys.side] = `${(size / rootSize) * 100}%`;
+        }, 0);
+      }
+    }
+  }, [keys, persistKey]);
 
   return (
-    <ResizableContext value={{ scope, orientation, createResizeHandler }}>
+    <ResizableContext value={{ scope, orientation, createResizeHandler, persist }}>
       <div
         ref={composeRefs(ref, scope)}
         className={cn(
@@ -175,7 +206,7 @@ const ResizablePanel = ({ asChild, className, children, ...props }: ResizablePan
       {/* Every panel but the first owns the handle on its leading edge. */}
       {index !== 0 && <ResizableHandle index={index} />}
       <Component
-        data-ui-resizable-panel=""
+        data-ui-resizable-panel={index}
         className={cn("min-h-0 w-full min-w-0 grow overflow-auto", className)}
         {...props}
       >
@@ -190,7 +221,7 @@ type ResizableHandleProps = {
 };
 
 const ResizableHandle = ({ index }: ResizableHandleProps) => {
-  const { orientation, createResizeHandler } = useResizableContext();
+  const { orientation, createResizeHandler, persist } = useResizableContext();
   const keyHandleRef = useRef<ResizeHandler | null>(null);
 
   const onPointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
@@ -214,6 +245,7 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
       document.body.style.cursor = prevCursor;
       document.body.style.userSelect = prevUserSelect;
       window.removeEventListener("pointermove", onDrag);
+      persist();
     };
 
     window.addEventListener("pointermove", onDrag);
@@ -226,6 +258,7 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
   };
 
   const onBlur = () => {
+    persist();
     keyHandleRef.current = null;
   };
 

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -237,8 +237,9 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
       aria-orientation={orientation === "horizontal" ? "vertical" : "horizontal"}
       tabIndex={0}
       className={cn(
-        "relative touch-none border-border",
+        "relative touch-none border-border outline-none ring-ring",
         "hover:border-foreground/24 hover:border-dashed active:border-foreground/48 active:border-dashed",
+        "focus-visible:ring-(length:--ring-width)",
         "after:absolute after:inset-0",
         orientation === "horizontal"
           ? "h-full w-px cursor-col-resize border-l after:-inset-x-2"

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -99,15 +99,20 @@ const Resizable = ({
       const panelBeforeRange = calcPanelRange(panelBefore, panelAfter);
       const panelAfterRange = calcPanelRange(panelAfter, panelBefore);
 
+      let cumulativeDelta = 0;
+
       const apply = (pxDelta: number) => {
-        const panelBeforeNew = panelBeforeCurrent + pxDelta;
-        const panelAfterNew = panelAfterCurrent - pxDelta;
+        const panelBeforeNew = panelBeforeCurrent + cumulativeDelta + pxDelta;
+        const panelAfterNew = panelAfterCurrent - (cumulativeDelta + pxDelta);
 
         // check if new size is within range
         if (panelBeforeNew < panelBeforeRange.min) return;
         if (panelAfterNew < panelAfterRange.min) return;
         if (panelBeforeNew > panelBeforeRange.max) return;
         if (panelAfterNew > panelAfterRange.max) return;
+
+        // only update cumulativeDelta if new size is within range
+        cumulativeDelta += pxDelta;
 
         panelBefore.style[keys.side] = `${(panelBeforeNew / rootCurrent) * 100}%`;
         panelAfter.style[keys.side] = `${(panelAfterNew / rootCurrent) * 100}%`;
@@ -186,6 +191,7 @@ type ResizableHandleProps = {
 
 const ResizableHandle = ({ index }: ResizableHandleProps) => {
   const { orientation, createResizeHandler } = useResizableContext();
+  const keyHandleRef = useRef<ResizeHandler | null>(null);
 
   const onPointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
     const clientOffset = orientation === "horizontal" ? "clientX" : "clientY";
@@ -197,9 +203,11 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
     document.body.style.cursor = orientation === "horizontal" ? "col-resize" : "row-resize";
     document.body.style.userSelect = "none";
 
+    let previousDelta = 0;
     const onDrag = ({ [clientOffset]: offset }: PointerEvent) => {
-      const delta = offset - startOffset;
-      handler.apply(delta);
+      const currentDelta = offset - startOffset - previousDelta;
+      previousDelta = offset - startOffset;
+      handler.apply(currentDelta);
     };
 
     const onDragEnd = () => {
@@ -213,8 +221,17 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
     window.addEventListener("pointercancel", onDragEnd, { once: true });
   };
 
+  const onFocus = () => {
+    keyHandleRef.current = createResizeHandler(index);
+  };
+
+  const onBlur = () => {
+    keyHandleRef.current = null;
+  };
+
   const onKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
-    const handler = createResizeHandler(index);
+    const handler = keyHandleRef.current;
+    if (!handler) return;
 
     const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
     const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
@@ -246,6 +263,8 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
           : "h-px w-full cursor-row-resize border-t after:-inset-y-2",
       )}
       onPointerDown={onPointerDown}
+      onFocus={onFocus}
+      onBlur={onBlur}
       onKeyDown={onKeydown}
     />
   );

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -136,7 +136,11 @@ const Resizable = ({
       const id = panel.getAttribute("data-ui-resizable-panel");
       if (id !== null) sizes[id] = panel.style[keys.side];
     }
-    localStorage.setItem(getLocalstorageKey(persistKey), JSON.stringify(sizes));
+    try {
+      localStorage.setItem(getLocalstorageKey(persistKey), JSON.stringify(sizes));
+    } catch {
+      // ignore localStorage errors
+    }
   }, [persistKey, keys.side]);
 
   // init and memo panels
@@ -161,18 +165,13 @@ const Resizable = ({
     const rootSize = root.getBoundingClientRect()[keys.side];
     for (const panel of panels.current) {
       const panelId = panel.getAttribute("data-ui-resizable-panel") || "0";
+      const size = panel.getBoundingClientRect()[keys.side];
       const persistedSize = persistedSizes[panelId];
 
-      if (persistedSize) {
-        setTimeout(() => {
-          panel.style[keys.side] = persistedSize;
-        }, 0);
-      } else {
-        const size = panel.getBoundingClientRect()[keys.side];
-        setTimeout(() => {
-          panel.style[keys.side] = `${(size / rootSize) * 100}%`;
-        }, 0);
-      }
+      // defer applying the size so subsequent panel size look-ups are accurate to the initial sizes
+      window.requestAnimationFrame(() => {
+        panel.style[keys.side] = persistedSize ? persistedSize : `${(size / rootSize) * 100}%`;
+      });
     }
   }, [keys, persistKey]);
 

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -167,7 +167,7 @@ const ResizablePanel = ({ asChild, className, style, children, ...props }: Resiz
       {index !== 0 && <ResizableHandle index={index} />}
       <Component
         data-ui-resizable-panel=""
-        className={cn("w-full overflow-auto", className)}
+        className={cn("w-full grow overflow-auto", className)}
         {...props}
       >
         {children}

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useId,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from "react";
 import { Slot } from "@/foundations/components/slot/slot";
@@ -15,22 +16,74 @@ import { composeRefs } from "@/foundations/utils/compose-refs/compose-refs";
 import { clamp } from "@/foundations/utils/math/clamp";
 import { cn } from "@/lib/utils/classnames";
 
+// Constants
+
 // The number of pixels to move when using the keyboard to resize.
 const KEYBOARD_ARROW_PX_STEP = 10;
 
+// Attribute a panel tags itself with, so handles can find their neighbours by
+// DOM traversal and the root can restore sizes on mount.
+const PANEL_ATTR = "data-ui-resizable-panel";
+
+// localStorage key prefix for persisted panel sizes.
+const STORAGE_PREFIX = "foundations-resizable:";
+
+type Orientation = "horizontal" | "vertical";
+
+// Everything that depends on the axis in one table, so component code reads a
+// value instead of re-deriving it from an `orientation === "horizontal"` ternary.
+const AXIS = {
+  horizontal: {
+    size: "width",
+    clientAxis: "clientX",
+    cursor: "col-resize",
+    back: "ArrowLeft",
+    forward: "ArrowRight",
+  },
+  vertical: {
+    size: "height",
+    clientAxis: "clientY",
+    cursor: "row-resize",
+    back: "ArrowUp",
+    forward: "ArrowDown",
+  },
+} as const;
+
+// Utils
+
+const noop = () => undefined;
+
 const findAdjacentPanel = (from: Element, direction: "next" | "previous") => {
-  let element = (
-    direction === "next" ? from.nextElementSibling : from.previousElementSibling
-  ) as HTMLElement | null;
-  while (element && !element.hasAttribute("data-ui-resizable-panel")) {
-    element = (
-      direction === "next" ? element.nextElementSibling : element.previousElementSibling
-    ) as HTMLElement | null;
+  const step = (el: Element) =>
+    direction === "next" ? el.nextElementSibling : el.previousElementSibling;
+
+  let element = step(from) as HTMLElement | null;
+  while (element && !element.hasAttribute(PANEL_ATTR)) {
+    element = step(element) as HTMLElement | null;
   }
   return element;
 };
 
-type Orientation = "horizontal" | "vertical";
+// Measure a panel's min/max size in px by momentarily forcing it (and its
+// neighbor) to the extremes, letting CSS min/max constraints clamp the result.
+const measureRange = (panel: HTMLElement, opposite: HTMLElement, size: "width" | "height") => {
+  const previous = { panel: panel.style[size], opposite: opposite.style[size] };
+
+  panel.style[size] = "0rem";
+  opposite.style[size] = "999rem";
+  const min = panel.getBoundingClientRect()[size];
+
+  panel.style[size] = "999rem";
+  opposite.style[size] = "0rem";
+  const max = panel.getBoundingClientRect()[size];
+
+  panel.style[size] = previous.panel;
+  opposite.style[size] = previous.opposite;
+
+  return { min, max };
+};
+
+// Context
 
 type RegisteredPanel = {
   id: string;
@@ -58,9 +111,15 @@ const useResizableContext = () => {
   return context;
 };
 
+// Components
+
 type ResizableProps = Omit<React.ComponentPropsWithRef<"div">, "onResize"> & {
   orientation?: Orientation;
-  persist: string;
+  /**
+   * Unique key used to save panel sizes to localStorage and restore them on the
+   * next visit. Omit to disable persistence.
+   */
+  persist?: string;
   children: React.ReactNode;
 };
 
@@ -75,7 +134,7 @@ const Resizable = ({
   const scope = useRef<HTMLDivElement>(null);
   const panels = useRef<Map<HTMLElement, RegisteredPanel>>(new Map());
 
-  const persistKey = persistId ? `foundations-resizable:${persistId}` : null;
+  const persistKey = persistId ? `${STORAGE_PREFIX}${persistId}` : null;
 
   const registerPanel = useCallback((element: HTMLElement, panel: RegisteredPanel) => {
     panels.current.set(element, panel);
@@ -87,11 +146,11 @@ const Resizable = ({
     const root = scope.current;
     if (!persistKey || !root) return;
 
-    const side = orientation === "horizontal" ? "width" : "height";
+    const { size } = AXIS[orientation];
 
     const sizes: Record<string, string> = {};
     for (const [element, { id }] of panels.current.entries()) {
-      sizes[id] = element.style[side];
+      sizes[id] = element.style[size];
     }
 
     try {
@@ -100,52 +159,26 @@ const Resizable = ({
   }, [persistKey, orientation]);
 
   const createResizeHandler = useCallback(
-    (panelBefore: HTMLElement, panelAfter: HTMLElement) => {
+    (panelBefore: HTMLElement, panelAfter: HTMLElement): ResizeHandler => {
       const root = scope.current;
       if (!root || !panelBefore || !panelAfter) {
-        return {
-          move: () => undefined,
-          set: () => undefined,
-          commit: () => undefined,
-        };
+        return { move: noop, set: noop, commit: noop };
       }
 
-      const side = orientation === "horizontal" ? "width" : "height";
+      const { size } = AXIS[orientation];
 
       // sizes when resize started
-      const rootCurrent = root.getBoundingClientRect()[side];
-      const panelBeforeCurrent = panelBefore.getBoundingClientRect()[side];
-      const panelAfterCurrent = panelAfter.getBoundingClientRect()[side];
+      const rootCurrent = root.getBoundingClientRect()[size];
+      const panelBeforeCurrent = panelBefore.getBoundingClientRect()[size];
+      const panelAfterCurrent = panelAfter.getBoundingClientRect()[size];
 
-      // calculate the min/max range for each panel based on its CSS properties
-      const calcPanelRange = (panel: HTMLElement, oppositePanel: HTMLElement) => {
-        const previousStyles = {
-          panel: panel.style[side],
-          oppositePanel: oppositePanel.style[side],
-        };
+      // size range for each panel, derived from its CSS min/max constraints
+      const panelBeforeRange = measureRange(panelBefore, panelAfter, size);
+      const panelAfterRange = measureRange(panelAfter, panelBefore, size);
 
-        panel.style[side] = "0rem";
-        oppositePanel.style[side] = "999rem";
-        const min = panel.getBoundingClientRect()[side];
-        panel.style[side] = "999rem";
-        oppositePanel.style[side] = "0rem";
-        const max = panel.getBoundingClientRect()[side];
-
-        panel.style[side] = previousStyles.panel;
-        oppositePanel.style[side] = previousStyles.oppositePanel;
-
-        return { min, max };
-      };
-
-      // size range for each panel
-      const panelBeforeRange = calcPanelRange(panelBefore, panelAfter);
-      const panelAfterRange = calcPanelRange(panelAfter, panelBefore);
-
-      // methods
-      const panelBeforeSnap = panels.current.get(panelBefore)?.snap;
-      const panelAfterSnap = panels.current.get(panelAfter)?.snap;
-      const panelBeforeOnResize = panels.current.get(panelBefore)?.onResize;
-      const panelAfterOnResize = panels.current.get(panelAfter)?.onResize;
+      // per-panel transformers/notifications registered on the panels
+      const before = panels.current.get(panelBefore);
+      const after = panels.current.get(panelAfter);
 
       // store how much we've moved so far (in px)
       // so we can easily calculate the new size from the current size
@@ -157,8 +190,8 @@ const Resizable = ({
 
       // write the pair as percentages of the root; they always sum to `combined`
       const write = (sizeBefore: number) => {
-        panelBefore.style[side] = `${(sizeBefore / rootCurrent) * 100}%`;
-        panelAfter.style[side] = `${((combined - sizeBefore) / rootCurrent) * 100}%`;
+        panelBefore.style[size] = `${(sizeBefore / rootCurrent) * 100}%`;
+        panelAfter.style[size] = `${((combined - sizeBefore) / rootCurrent) * 100}%`;
       };
 
       const move = (pxDelta: number) => {
@@ -177,14 +210,14 @@ const Resizable = ({
         // a snap transformer returns the size its panel should take; the other
         // panel absorbs the difference (write derives it from `combined`)
         let sizeBefore = panelBeforeNew;
-        if (panelBeforeSnap) sizeBefore = panelBeforeSnap(panelBeforeNew);
-        else if (panelAfterSnap) sizeBefore = combined - panelAfterSnap(panelAfterNew);
+        if (before?.snap) sizeBefore = before.snap(panelBeforeNew);
+        else if (after?.snap) sizeBefore = combined - after.snap(panelAfterNew);
 
         write(sizeBefore);
 
         // read-only notifications get the raw pointer-tracked size (pre-snap)
-        panelBeforeOnResize?.(panelBeforeNew);
-        panelAfterOnResize?.(panelAfterNew);
+        before?.onResize?.(panelBeforeNew);
+        after?.onResize?.(panelAfterNew);
       };
 
       // set the leading panel to an absolute size, clamped to its range; no snap
@@ -203,7 +236,7 @@ const Resizable = ({
     const root = scope.current;
     if (!root) return;
 
-    const side = orientation === "horizontal" ? "width" : "height";
+    const { size } = AXIS[orientation];
 
     let persistedSizes: Record<string, string> = {};
     if (persistKey) {
@@ -213,21 +246,26 @@ const Resizable = ({
       } catch {} // ignore malformed storage values
     }
 
-    const rootSize = root.getBoundingClientRect()[side];
-    for (const panel of root.querySelectorAll<HTMLElement>("& > [data-ui-resizable-panel]")) {
-      const panelId = panel.getAttribute("data-ui-resizable-panel") || "unknown";
-      const size = panel.getBoundingClientRect()[side];
+    const rootSize = root.getBoundingClientRect()[size];
+    for (const panel of root.querySelectorAll<HTMLElement>(`& > [${PANEL_ATTR}]`)) {
+      const panelId = panel.getAttribute(PANEL_ATTR) || "unknown";
+      const panelSize = panel.getBoundingClientRect()[size];
       const persistedSize = persistedSizes[panelId];
 
       // defer applying the size so subsequent panel size look-ups are accurate to the initial sizes
       window.requestAnimationFrame(() => {
-        panel.style[side] = persistedSize ? persistedSize : `${(size / rootSize) * 100}%`;
+        panel.style[size] = persistedSize ? persistedSize : `${(panelSize / rootSize) * 100}%`;
       });
     }
   }, [orientation, persistKey]);
 
+  const context = useMemo<ResizableContextValue>(
+    () => ({ orientation, registerPanel, createResizeHandler }),
+    [orientation, registerPanel, createResizeHandler],
+  );
+
   return (
-    <ResizableContext value={{ orientation, registerPanel, createResizeHandler }}>
+    <ResizableContext value={context}>
       <div
         ref={composeRefs(ref, scope)}
         className={cn(
@@ -243,14 +281,14 @@ const Resizable = ({
   );
 };
 
-type ResizablePanelRef = {
+type ResizablePanelHandle = {
   /** Set the panel's size in pixels. The adjacent panel absorbs the difference. */
   resize: (size: number) => void;
 };
 
 type ResizablePanelProps = Omit<React.ComponentPropsWithRef<"div">, "ref"> & {
   /** Imperative handle to set this panel's size programmatically. */
-  ref?: React.Ref<ResizablePanelRef>;
+  ref?: React.Ref<ResizablePanelHandle>;
   asChild?: boolean;
   /**
    * Transform the panel's size during a resize: receives the pointer-tracked
@@ -295,11 +333,7 @@ const ResizablePanel = ({
     const element = ref.current;
     if (!element) return;
 
-    return registerPanel(element, {
-      id,
-      snap,
-      onResize,
-    });
+    return registerPanel(element, { id, snap, onResize });
   }, [registerPanel, id, snap, onResize]);
 
   const Component = asChild ? Slot : "div";
@@ -346,18 +380,18 @@ const ResizableHandle = ({
     const { panelBefore, panelAfter } = getAdjacentPanels();
     if (!panelBefore || !panelAfter) return;
 
-    const clientOffset = orientation === "horizontal" ? "clientX" : "clientY";
-    const startOffset = event[clientOffset];
+    const { clientAxis, cursor } = AXIS[orientation];
+    const startOffset = event[clientAxis];
 
     const handler = createResizeHandler(panelBefore, panelAfter);
 
     const prevCursor = document.body.style.cursor;
     const prevUserSelect = document.body.style.userSelect;
-    document.body.style.cursor = orientation === "horizontal" ? "col-resize" : "row-resize";
+    document.body.style.cursor = cursor;
     document.body.style.userSelect = "none";
 
     let previousDelta = 0;
-    const onDrag = ({ [clientOffset]: offset }: PointerEvent) => {
+    const onDrag = ({ [clientAxis]: offset }: PointerEvent) => {
       const currentDelta = offset - startOffset - previousDelta;
       previousDelta = offset - startOffset;
       handler.move(currentDelta);
@@ -401,8 +435,7 @@ const ResizableHandle = ({
     const handler = keyHandlerRef.current;
     if (!handler) return;
 
-    const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
-    const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
+    const { back, forward } = AXIS[orientation];
 
     if (event.key === forward) {
       event.preventDefault();
@@ -450,6 +483,7 @@ const CompoundResizable = Object.assign(Resizable, {
 export {
   CompoundResizable as Resizable,
   type ResizableHandleProps,
+  type ResizablePanelHandle,
   type ResizablePanelProps,
   type ResizableProps,
 };

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -14,33 +14,20 @@ import {
 } from "@/foundations/components/instance-counter/instance-counter";
 import { Slot } from "@/foundations/components/slot/slot";
 import { composeRefs } from "@/foundations/utils/compose-refs/compose-refs";
-import { clamp } from "@/foundations/utils/math/clamp";
 import { cn } from "@/lib/utils/classnames";
+
+const KEYBOARD_ARROW_PX_STEP = 10;
 
 type Orientation = "horizontal" | "vertical";
 
-const getElementDimensionRange = (element: HTMLElement, orientation: Orientation) => {
-  const key = orientation === "horizontal" ? "width" : "height";
-  const previous = element.style[key];
-
-  element.style[key] = "0";
-  const min = element.getBoundingClientRect()[key];
-  element.style[key] = "100%";
-  const max = element.getBoundingClientRect()[key];
-
-  element.style[key] = previous;
-
-  return { min, max };
-};
-
-type ResizeHandler = (index: number) => {
+type ResizeHandler = {
   apply: (pxDelta: number) => void;
 };
 
 type ResizableContextValue = {
   orientation: Orientation;
   scope: React.RefObject<HTMLDivElement | null>;
-  createResizeHandler: ResizeHandler;
+  createResizeHandler: (index: number) => ResizeHandler;
 };
 
 const ResizableContext = createContext<ResizableContextValue | null>(null);
@@ -74,11 +61,11 @@ const Resizable = ({
     } as const;
   }, [orientation]);
 
-  const createResizeHandler: ResizeHandler = useCallback(
-    (index: number) => {
+  const createResizeHandler = useCallback(
+    (handleIndex: number) => {
       const root = scope.current;
-      const panelBefore = panels.current[index - 1];
-      const panelAfter = panels.current[index];
+      const panelBefore = panels.current[handleIndex - 1];
+      const panelAfter = panels.current[handleIndex];
 
       if (!root || !panelBefore || !panelAfter) {
         return { apply: () => undefined };
@@ -86,24 +73,42 @@ const Resizable = ({
 
       // sizes when drag started
       const rootCurrent = root[keys.sideOffset];
-      const panelBeforeCurrent = panelBefore[keys.sideOffset];
-      const panelAfterCurrent = panelAfter[keys.sideOffset];
+      const panelBeforeCurrent = panelBefore.getBoundingClientRect()[keys.side];
+      const panelAfterCurrent = panelAfter.getBoundingClientRect()[keys.side];
+
+      const calcPanelRange = (panel: HTMLElement, oppositePanel: HTMLElement) => {
+        const key = orientation === "horizontal" ? "width" : "height";
+        const previousStyles = {
+          panel: panel.style[key],
+          oppositePanel: oppositePanel.style[key],
+        };
+
+        panel.style[key] = "0rem";
+        oppositePanel.style[key] = "999rem";
+        const min = panel.getBoundingClientRect()[key];
+        panel.style[key] = "999rem";
+        oppositePanel.style[key] = "0rem";
+        const max = panel.getBoundingClientRect()[key];
+
+        panel.style[key] = previousStyles.panel;
+        oppositePanel.style[key] = previousStyles.oppositePanel;
+
+        return { min, max };
+      };
 
       // size range for each panel
-      const panelBeforeRange = getElementDimensionRange(panelBefore, orientation);
-      const panelAfterRange = getElementDimensionRange(panelAfter, orientation);
+      const panelBeforeRange = calcPanelRange(panelBefore, panelAfter);
+      const panelAfterRange = calcPanelRange(panelAfter, panelBefore);
 
       const apply = (pxDelta: number) => {
-        const panelBeforeNew = clamp(
-          panelBeforeRange.min,
-          panelBeforeCurrent + pxDelta,
-          panelBeforeRange.max,
-        );
-        const panelAfterNew = clamp(
-          panelAfterRange.min,
-          panelAfterCurrent - pxDelta,
-          panelAfterRange.max,
-        );
+        const panelBeforeNew = panelBeforeCurrent + pxDelta;
+        const panelAfterNew = panelAfterCurrent - pxDelta;
+
+        // check if new size is within range
+        if (panelBeforeNew < panelBeforeRange.min) return;
+        if (panelAfterNew < panelAfterRange.min) return;
+        if (panelBeforeNew > panelBeforeRange.max) return;
+        if (panelAfterNew > panelAfterRange.max) return;
 
         panelBefore.style[keys.side] = `${(panelBeforeNew / rootCurrent) * 100}%`;
         panelAfter.style[keys.side] = `${(panelAfterNew / rootCurrent) * 100}%`;
@@ -124,6 +129,7 @@ const Resizable = ({
     // Normalize panels widths: each panel gets fraction of the total width
     for (const panel of panels.current) {
       const size = panel[keys.sideOffset];
+
       setTimeout(() => {
         panel.style.width = `${(size / root.offsetWidth) * 100}%`;
       }, 0);
@@ -196,19 +202,18 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
   };
 
   const onKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
-    const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
-    const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
-
     const handler = createResizeHandler(index);
 
+    const back = orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
+    const forward = orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
     if (event.key === forward) {
       event.preventDefault();
-      return handler.apply(10);
+      return handler.apply(KEYBOARD_ARROW_PX_STEP);
     }
 
     if (event.key === back) {
       event.preventDefault();
-      return handler.apply(-10);
+      return handler.apply(-KEYBOARD_ARROW_PX_STEP);
     }
   };
 

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -123,8 +123,12 @@ const Resizable = ({
     const root = scope.current;
     if (!root) return;
 
-    panels.current = [...root.querySelectorAll<HTMLElement>("[data-ui-resizable-panel]")];
     const rootSize = root.getBoundingClientRect()[keys.side];
+
+    panels.current = Array.from(root.children).filter(
+      (child): child is HTMLElement =>
+        child instanceof HTMLElement && child.hasAttribute("data-ui-resizable-panel"),
+    );
 
     // Normalize panels widths: each panel gets fraction of the total width
     for (const panel of panels.current) {
@@ -206,6 +210,7 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
 
     window.addEventListener("pointermove", onDrag);
     window.addEventListener("pointerup", onDragEnd, { once: true });
+    window.addEventListener("pointercancel", onDragEnd, { once: true });
   };
 
   const onKeydown: KeyboardEventHandler<HTMLDivElement> = (event) => {
@@ -229,10 +234,10 @@ const ResizableHandle = ({ index }: ResizableHandleProps) => {
     <div
       // biome-ignore lint/a11y/useAriaPropsForRole: hr element does not support after pseudo element
       role="separator"
-      aria-orientation={orientation}
+      aria-orientation={orientation === "horizontal" ? "vertical" : "horizontal"}
       tabIndex={0}
       className={cn(
-        "relative border-border border-l",
+        "relative touch-none border-border",
         "hover:border-foreground/24 hover:border-dashed active:border-foreground/48 active:border-dashed",
         "after:absolute after:inset-0",
         orientation === "horizontal"

--- a/src/foundations/ui/resizable/resizable.tsx
+++ b/src/foundations/ui/resizable/resizable.tsx
@@ -85,10 +85,12 @@ const measureRange = (panel: HTMLElement, opposite: HTMLElement, size: "width" |
 
 // Context
 
-type RegisteredPanel = {
-  id: string;
-  onResize?: (size: number) => void;
+// A panel only appears here if it opts into resize behavior; plain layout
+// panels never touch this map. Keyed by element, read by the shared resize
+// handler that a Handle drives.
+type PanelBehavior = {
   snap?: (size: number) => number;
+  onResize?: (size: number) => void;
 };
 
 type ResizeHandler = {
@@ -99,7 +101,7 @@ type ResizeHandler = {
 
 type ResizableContextValue = {
   orientation: Orientation;
-  registerPanel: (element: HTMLElement, panel: RegisteredPanel) => () => void;
+  behaviors: WeakMap<HTMLElement, PanelBehavior>;
   createResizeHandler: (beforePanel: HTMLElement, afterPanel: HTMLElement) => ResizeHandler;
 };
 
@@ -132,16 +134,12 @@ const Resizable = ({
   ...props
 }: ResizableProps) => {
   const scope = useRef<HTMLDivElement>(null);
-  const panels = useRef<Map<HTMLElement, RegisteredPanel>>(new Map());
+  const behaviors = useRef<WeakMap<HTMLElement, PanelBehavior>>(new WeakMap());
 
   const persistKey = persistId ? `${STORAGE_PREFIX}${persistId}` : null;
 
-  const registerPanel = useCallback((element: HTMLElement, panel: RegisteredPanel) => {
-    panels.current.set(element, panel);
-    return () => panels.current.delete(element);
-  }, []);
-
-  // Persist panel sizes to localStorage
+  // Persist panel sizes to localStorage, reading each panel's id off its
+  // `data-ui-resizable-panel` attribute (same source the restore effect uses).
   const persist = useCallback(() => {
     const root = scope.current;
     if (!persistKey || !root) return;
@@ -149,8 +147,9 @@ const Resizable = ({
     const { size } = AXIS[orientation];
 
     const sizes: Record<string, string> = {};
-    for (const [element, { id }] of panels.current.entries()) {
-      sizes[id] = element.style[size];
+    for (const panel of root.querySelectorAll<HTMLElement>(`& > [${PANEL_ATTR}]`)) {
+      const id = panel.getAttribute(PANEL_ATTR) || "unknown";
+      sizes[id] = panel.style[size];
     }
 
     try {
@@ -176,9 +175,9 @@ const Resizable = ({
       const panelBeforeRange = measureRange(panelBefore, panelAfter, size);
       const panelAfterRange = measureRange(panelAfter, panelBefore, size);
 
-      // per-panel transformers/notifications registered on the panels
-      const before = panels.current.get(panelBefore);
-      const after = panels.current.get(panelAfter);
+      // per-panel transformers/notifications (undefined for plain panels)
+      const before = behaviors.current.get(panelBefore);
+      const after = behaviors.current.get(panelAfter);
 
       // store how much we've moved so far (in px)
       // so we can easily calculate the new size from the current size
@@ -260,8 +259,8 @@ const Resizable = ({
   }, [orientation, persistKey]);
 
   const context = useMemo<ResizableContextValue>(
-    () => ({ orientation, registerPanel, createResizeHandler }),
-    [orientation, registerPanel, createResizeHandler],
+    () => ({ orientation, behaviors: behaviors.current, createResizeHandler }),
+    [orientation, createResizeHandler],
   );
 
   return (
@@ -309,7 +308,7 @@ const ResizablePanel = ({
   children,
   ...props
 }: ResizablePanelProps) => {
-  const { registerPanel, createResizeHandler } = useResizableContext();
+  const { behaviors, createResizeHandler } = useResizableContext();
   const id = useId();
   const ref = useRef<HTMLDivElement>(null);
 
@@ -329,12 +328,16 @@ const ResizablePanel = ({
     },
   }));
 
+  // Only panels that opt into resize behavior publish anything to the parent.
   useEffect(() => {
     const element = ref.current;
-    if (!element) return;
+    if (!element || (!snap && !onResize)) return;
 
-    return registerPanel(element, { id, snap, onResize });
-  }, [registerPanel, id, snap, onResize]);
+    behaviors.set(element, { snap, onResize });
+    return () => {
+      behaviors.delete(element);
+    };
+  }, [behaviors, snap, onResize]);
 
   const Component = asChild ? Slot : "div";
   return (


### PR DESCRIPTION
  Introduces a Resizable compound component that splits a container into panels separated by draggable handles.

  - Handles are inferred — no extra markup, each panel renders one on its leading edge
  - Multi-panel resize works correctly: sizes are snapshotted on drag start and only the two adjacent panels are redistributed, leaving all others untouched
  - Bounds are derived from the panels' CSS min-* / max-* constraints, no props needed
  - Keyboard support: arrow keys nudge the focused handle by 10px
  - Horizontal and vertical orientations; panels can contain nested Resizable instances